### PR TITLE
Fix future toolchain build failure

### DIFF
--- a/src/include/openssl/arm_arch.h
+++ b/src/include/openssl/arm_arch.h
@@ -92,7 +92,7 @@
 #   define __ARM_ARCH__ 5
 #  elif	defined(__ARM_ARCH_4__)	|| defined(__ARM_ARCH_4T__)
 #   define __ARM_ARCH__ 4
-#  else
+#  elif !TARGET_OS_SIMULATOR // Apple future toolchain builds all public headers
 #   error "unsupported ARM architecture"
 #  endif
 # endif


### PR DESCRIPTION
Avoid compilation failure on simulator builds on the future Apple toolchain.

The future Apple toolchain builds all public headers so it fails building arm_arch.h which only expects to be built for device.

This change avoids that compilation and is a no-op for the current toolchain which doesn't see the file at all for simulator and doesn't reach the new `#elif` for device.

There may be problems for the future toolchain on Arm M1 Macs, but this change shouldn't make it better or worse.

More context at https://github.com/firebase/firebase-ios-sdk/issues/7784 and its links.