### PR TITLE
32bit conversion warning fix for boringSSL SwiftPM

### DIFF
--- a/src/crypto/asn1/a_enum.c
+++ b/src/crypto/asn1/a_enum.c
@@ -175,7 +175,7 @@ ASN1_ENUMERATED *BN_to_ASN1_ENUMERATED(const BIGNUM *bn, ASN1_ENUMERATED *ai)
         ret->data = new_data;
     }
 
-    ret->length = BN_bn2bin(bn, ret->data);
+    ret->length = (int)BN_bn2bin(bn, ret->data);
     return (ret);
  err:
     if (ret != ai)

--- a/src/crypto/asn1/a_gentm.c
+++ b/src/crypto/asn1/a_gentm.c
@@ -191,7 +191,7 @@ int ASN1_GENERALIZEDTIME_set_string(ASN1_GENERALIZEDTIME *s, const char *str)
     ASN1_GENERALIZEDTIME t;
 
     t.type = V_ASN1_GENERALIZEDTIME;
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     if (ASN1_GENERALIZEDTIME_check(&t)) {
         if (s != NULL) {
@@ -256,7 +256,7 @@ ASN1_GENERALIZEDTIME *ASN1_GENERALIZEDTIME_adj(ASN1_GENERALIZEDTIME *s,
     BIO_snprintf(p, len, "%04d%02d%02d%02d%02d%02dZ", ts->tm_year + 1900,
                  ts->tm_mon + 1, ts->tm_mday, ts->tm_hour, ts->tm_min,
                  ts->tm_sec);
-    tmps->length = strlen(p);
+    tmps->length = (int)strlen(p);
     tmps->type = V_ASN1_GENERALIZEDTIME;
     return tmps;
  err:

--- a/src/crypto/asn1/a_int.c
+++ b/src/crypto/asn1/a_int.c
@@ -236,7 +236,7 @@ ASN1_INTEGER *c2i_ASN1_INTEGER(ASN1_INTEGER **a, const unsigned char **pp,
             p++;
             len--;
         }
-        i = len;
+        i = (int)len;
         p += i - 1;
         to += i - 1;
         while ((!*p) && i) {
@@ -323,7 +323,7 @@ int ASN1_INTEGER_set_uint64(ASN1_INTEGER *out, uint64_t v)
         }
     }
 
-    out->length = sizeof(uint64_t) - leading_zeros;
+    out->length = (int)(sizeof(uint64_t) - leading_zeros);
     OPENSSL_memmove(out->data, out->data + leading_zeros, out->length);
 
     return 1;
@@ -395,7 +395,7 @@ ASN1_INTEGER *BN_to_ASN1_INTEGER(const BIGNUM *bn, ASN1_INTEGER *ai)
         }
         ret->data = new_data;
     }
-    ret->length = BN_bn2bin(bn, ret->data);
+    ret->length = (int)(BN_bn2bin(bn, ret->data));
     /* Correct zero case */
     if (!ret->length) {
         ret->data[0] = 0;

--- a/src/crypto/asn1/a_mbstr.c
+++ b/src/crypto/asn1/a_mbstr.c
@@ -95,7 +95,7 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
     size_t nchar = 0;
     char strbuf[32];
     if (len == -1)
-        len = strlen((const char *)in);
+        len = (int)strlen((const char *)in);
     if (!mask)
         mask = DIRSTRING_TYPE;
 

--- a/src/crypto/asn1/a_object.c
+++ b/src/crypto/asn1/a_object.c
@@ -112,7 +112,7 @@ int i2t_ASN1_OBJECT(char *buf, int buf_len, const ASN1_OBJECT *a)
 
 static int write_str(BIO *bp, const char *str)
 {
-    int len = strlen(str);
+    int len = (int)strlen(str);
     return BIO_write(bp, str, len) == len ? len : -1;
 }
 

--- a/src/crypto/asn1/a_print.c
+++ b/src/crypto/asn1/a_print.c
@@ -64,7 +64,7 @@
 int ASN1_PRINTABLE_type(const unsigned char *s, int len)
 {
     if (len < 0) {
-        len = strlen((const char *)s);
+        len = (int)strlen((const char *)s);
     }
 
     int printable = 1;

--- a/src/crypto/asn1/a_time.c
+++ b/src/crypto/asn1/a_time.c
@@ -164,7 +164,7 @@ int ASN1_TIME_set_string(ASN1_TIME *s, const char *str)
 {
     ASN1_TIME t;
 
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     t.flags = 0;
 

--- a/src/crypto/asn1/a_utctm.c
+++ b/src/crypto/asn1/a_utctm.c
@@ -167,7 +167,7 @@ int ASN1_UTCTIME_set_string(ASN1_UTCTIME *s, const char *str)
     ASN1_UTCTIME t;
 
     t.type = V_ASN1_UTCTIME;
-    t.length = strlen(str);
+    t.length = (int)strlen(str);
     t.data = (unsigned char *)str;
     if (ASN1_UTCTIME_check(&t)) {
         if (s != NULL) {
@@ -229,7 +229,7 @@ ASN1_UTCTIME *ASN1_UTCTIME_adj(ASN1_UTCTIME *s, time_t t,
     BIO_snprintf(p, len, "%02d%02d%02d%02d%02d%02dZ", ts->tm_year % 100,
                  ts->tm_mon + 1, ts->tm_mday, ts->tm_hour, ts->tm_min,
                  ts->tm_sec);
-    s->length = strlen(p);
+    s->length = (int)strlen(p);
     s->type = V_ASN1_UTCTIME;
     return (s);
  err:

--- a/src/crypto/asn1/asn1_lib.c
+++ b/src/crypto/asn1/asn1_lib.c
@@ -329,7 +329,7 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len)
         if (data == NULL)
             return (0);
         else
-            len = strlen(data);
+            len = (int)strlen(data);
     }
     if ((str->length <= len) || (str->data == NULL)) {
         c = str->data;

--- a/src/crypto/asn1/tasn_dec.c
+++ b/src/crypto/asn1/tasn_dec.c
@@ -437,7 +437,7 @@ static int asn1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in,
             }
         }
         /* Save encoding */
-        if (!asn1_enc_save(pval, *in, p - *in, it))
+        if (!asn1_enc_save(pval, *in, (int)(p - *in), it))
             goto auxerr;
         if (asn1_cb && !asn1_cb(ASN1_OP_D2I_POST, pval, it, NULL))
             goto auxerr;
@@ -484,7 +484,7 @@ static int asn1_template_ex_d2i(ASN1_VALUE **val,
     const unsigned char *p, *q;
     if (!val)
         return 0;
-    flags = tt->flags;
+    flags = (int)(tt->flags);
     aclass = flags & ASN1_TFLG_TAG_CLASS;
 
     p = *in;
@@ -497,7 +497,7 @@ static int asn1_template_ex_d2i(ASN1_VALUE **val,
          * where it starts: so read in EXPLICIT header to get the info.
          */
         ret = asn1_check_tlen(&len, NULL, NULL, &cst,
-                              &p, inlen, tt->tag, aclass, opt, ctx);
+                              &p, inlen, (int)(tt->tag), aclass, opt, ctx);
         q = p;
         if (!ret) {
             OPENSSL_PUT_ERROR(ASN1, ASN1_R_NESTED_ASN1_ERROR);
@@ -542,7 +542,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
     const unsigned char *p;
     if (!val)
         return 0;
-    flags = tt->flags;
+    flags = (int)(tt->flags);
     aclass = flags & ASN1_TFLG_TAG_CLASS;
 
     p = *in;
@@ -552,7 +552,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
         int sktag, skaclass;
         /* First work out expected inner tag value */
         if (flags & ASN1_TFLG_IMPTAG) {
-            sktag = tt->tag;
+            sktag = (int)(tt->tag);
             skaclass = aclass;
         } else {
             skaclass = V_ASN1_UNIVERSAL;
@@ -614,7 +614,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
         }
     } else if (flags & ASN1_TFLG_IMPTAG) {
         /* IMPLICIT tagging */
-        ret = asn1_item_ex_d2i(val, &p, len, ASN1_ITEM_ptr(tt->item), tt->tag,
+        ret = asn1_item_ex_d2i(val, &p, len, ASN1_ITEM_ptr(tt->item), (int)(tt->tag),
                                aclass, opt, ctx, depth);
         if (!ret) {
             OPENSSL_PUT_ERROR(ASN1, ASN1_R_NESTED_ASN1_ERROR);
@@ -661,7 +661,7 @@ static int asn1_d2i_ex_primitive(ASN1_VALUE **pval,
         utype = tag;
         tag = -1;
     } else
-        utype = it->utype;
+        utype = (int)(it->utype);
 
     if (utype == V_ASN1_ANY) {
         /* If type is ANY need to figure out type from tag */
@@ -730,7 +730,7 @@ static int asn1_d2i_ex_primitive(ASN1_VALUE **pval,
     }
 
     /* We now have content length and type: translate into a structure */
-    if (!asn1_ex_c2i(pval, cont, len, utype, it))
+    if (!asn1_ex_c2i(pval, cont, (int)len, utype, it))
         goto err;
 
     *in = p;
@@ -912,7 +912,7 @@ static int asn1_check_tlen(long *olen, int *otag, unsigned char *oclass,
             ctx->plen = plen;
             ctx->pclass = pclass;
             ctx->ptag = ptag;
-            ctx->hdrlen = p - q;
+            ctx->hdrlen = (int)(p - q);
             ctx->valid = 1;
             /*
              * If no error, length + header can't exceed total amount of data

--- a/src/crypto/asn1/tasn_enc.c
+++ b/src/crypto/asn1/tasn_enc.c
@@ -272,7 +272,7 @@ static int asn1_template_ex_i2d(ASN1_VALUE **pval, unsigned char **out,
 {
     int i, ret, flags, ttag, tclass;
     size_t j;
-    flags = tt->flags;
+    flags = (int)(tt->flags);
 
     /* Historically, |iclass| was repurposed to pass additional flags into the
      * encoding process. */
@@ -292,7 +292,7 @@ static int asn1_template_ex_i2d(ASN1_VALUE **pval, unsigned char **out,
             return -1;
         }
         /* Get tagging from template */
-        ttag = tt->tag;
+        ttag = (int)(tt->tag);
         tclass = flags & ASN1_TFLG_TAG_CLASS;
     } else if (tag != -1) {
         /* No template tagging, get from arguments */
@@ -500,7 +500,7 @@ static int asn1_i2d_ex_primitive(ASN1_VALUE **pval, unsigned char **out,
 {
     /* Get length of content octets and maybe find out the underlying type. */
     int omit;
-    int utype = it->utype;
+    int utype = (int)(it->utype);
     int len = asn1_ex_i2c(pval, NULL, &omit, &utype, it);
     if (len < 0) {
         return -1;

--- a/src/crypto/asn1/tasn_fre.c
+++ b/src/crypto/asn1/tasn_fre.c
@@ -199,7 +199,7 @@ void ASN1_primitive_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
         if (!*pval)
             return;
     } else {
-        utype = it->utype;
+        utype = (int)(it->utype);
         if ((utype != V_ASN1_BOOLEAN) && !*pval)
             return;
     }
@@ -211,7 +211,7 @@ void ASN1_primitive_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
 
     case V_ASN1_BOOLEAN:
         if (it)
-            *(ASN1_BOOLEAN *)pval = it->size;
+            *(ASN1_BOOLEAN *)pval = (ASN1_BOOLEAN)(it->size);
         else
             *(ASN1_BOOLEAN *)pval = -1;
         return;

--- a/src/crypto/asn1/tasn_new.c
+++ b/src/crypto/asn1/tasn_new.c
@@ -283,14 +283,14 @@ static int ASN1_primitive_new(ASN1_VALUE **pval, const ASN1_ITEM *it)
     if (it->itype == ASN1_ITYPE_MSTRING)
         utype = -1;
     else
-        utype = it->utype;
+        utype = (int)(it->utype);
     switch (utype) {
     case V_ASN1_OBJECT:
         *pval = (ASN1_VALUE *)OBJ_nid2obj(NID_undef);
         return 1;
 
     case V_ASN1_BOOLEAN:
-        *(ASN1_BOOLEAN *)pval = it->size;
+        *(ASN1_BOOLEAN *)pval = (ASN1_BOOLEAN)(it->size);
         return 1;
 
     case V_ASN1_NULL:
@@ -324,9 +324,9 @@ static void asn1_primitive_clear(ASN1_VALUE **pval, const ASN1_ITEM *it)
     if (!it || (it->itype == ASN1_ITYPE_MSTRING))
         utype = -1;
     else
-        utype = it->utype;
+        utype = (int)(it->utype);
     if (utype == V_ASN1_BOOLEAN)
-        *(ASN1_BOOLEAN *)pval = it->size;
+        *(ASN1_BOOLEAN *)pval = (ASN1_BOOLEAN)(it->size);
     else
         *pval = NULL;
 }

--- a/src/crypto/asn1/tasn_utl.c
+++ b/src/crypto/asn1/tasn_utl.c
@@ -200,7 +200,7 @@ int asn1_enc_restore(int *len, unsigned char **out, ASN1_VALUE **pval,
     *out += enc->len;
   }
   if (len) {
-    *len = enc->len;
+    *len = (int)(enc->len);
   }
   return 1;
 }

--- a/src/crypto/asn1/time_support.c
+++ b/src/crypto/asn1/time_support.c
@@ -93,10 +93,10 @@ static void julian_to_date(long jd, int *y, int *m, int *d) {
   i = (4000 * (L + 1)) / 1461001;
   L = L - (1461 * i) / 4 + 31;
   j = (80 * L) / 2447;
-  *d = L - (2447 * j) / 80;
+  *d = (int)(L - (2447 * j) / 80);
   L = j / 11;
-  *m = j + 2 - (12 * L);
-  *y = 100 * (n - 49) + i + L;
+  *m = (int)(j + 2 - (12 * L));
+  *y = (int)(100 * (n - 49) + i + L);
 }
 
 /* Convert tm structure and offset into julian day and seconds */
@@ -106,9 +106,9 @@ static int julian_adj(const struct tm *tm, int off_day, long offset_sec,
   long time_jd;
   int time_year, time_month, time_day;
   /* split offset into days and day seconds */
-  offset_day = offset_sec / SECS_PER_DAY;
+  offset_day = (int)(offset_sec / SECS_PER_DAY);
   /* Avoid sign issues with % operator */
-  offset_hms = offset_sec - (offset_day * SECS_PER_DAY);
+  offset_hms = (int)(offset_sec - (offset_day * SECS_PER_DAY));
   offset_day += off_day;
   /* Add current time seconds to offset */
   offset_hms += tm->tm_hour * 3600 + tm->tm_min * 60 + tm->tm_sec;

--- a/src/crypto/bio/bio.c
+++ b/src/crypto/bio/bio.c
@@ -192,11 +192,11 @@ int BIO_write_all(BIO *bio, const void *data, size_t len) {
 }
 
 int BIO_puts(BIO *bio, const char *in) {
-  return BIO_write(bio, in, strlen(in));
+  return BIO_write(bio, in, (int)strlen(in));
 }
 
 int BIO_flush(BIO *bio) {
-  return BIO_ctrl(bio, BIO_CTRL_FLUSH, 0, NULL);
+  return (int)BIO_ctrl(bio, BIO_CTRL_FLUSH, 0, NULL);
 }
 
 long BIO_ctrl(BIO *bio, int cmd, long larg, void *parg) {
@@ -229,11 +229,11 @@ long BIO_int_ctrl(BIO *b, int cmd, long larg, int iarg) {
 }
 
 int BIO_reset(BIO *bio) {
-  return BIO_ctrl(bio, BIO_CTRL_RESET, 0, NULL);
+  return (int)BIO_ctrl(bio, BIO_CTRL_RESET, 0, NULL);
 }
 
 int BIO_eof(BIO *bio) {
-  return BIO_ctrl(bio, BIO_CTRL_EOF, 0, NULL);
+  return (int)BIO_ctrl(bio, BIO_CTRL_EOF, 0, NULL);
 }
 
 void BIO_set_flags(BIO *bio, int flags) {
@@ -333,7 +333,7 @@ size_t BIO_wpending(const BIO *bio) {
 }
 
 int BIO_set_close(BIO *bio, int close_flag) {
-  return BIO_ctrl(bio, BIO_CTRL_SET_CLOSE, close_flag, NULL);
+  return (int)BIO_ctrl(bio, BIO_CTRL_SET_CLOSE, close_flag, NULL);
 }
 
 OPENSSL_EXPORT size_t BIO_number_read(const BIO *bio) {
@@ -418,7 +418,7 @@ int BIO_indent(BIO *bio, unsigned indent, unsigned max_indent) {
 }
 
 static int print_bio(const char *str, size_t len, void *bio) {
-  return BIO_write((BIO *)bio, str, len);
+  return BIO_write((BIO *)bio, str, (int)len);
 }
 
 void ERR_print_errors(BIO *bio) {
@@ -459,7 +459,7 @@ static int bio_read_all(BIO *bio, uint8_t **out, size_t *out_len,
     }
     const size_t todo = len - done;
     assert(todo < INT_MAX);
-    const int n = BIO_read(bio, *out + done, todo);
+    const int n = BIO_read(bio, *out + done, (int)todo);
     if (n == 0) {
       *out_len = done;
       return 1;

--- a/src/crypto/bio/bio_mem.c
+++ b/src/crypto/bio/bio_mem.c
@@ -136,7 +136,7 @@ static int mem_read(BIO *bio, char *out, int outl) {
   BIO_clear_retry_flags(bio);
   ret = outl;
   if (b->length < INT_MAX && ret > (int)b->length) {
-    ret = b->length;
+    ret = (int)(b->length);
   }
 
   if (ret > 0) {
@@ -169,7 +169,7 @@ static int mem_write(BIO *bio, const char *in, int inl) {
   }
 
   BIO_clear_retry_flags(bio);
-  blen = b->length;
+  blen = (int)(b->length);
   if (INT_MAX - blen < inl) {
     goto err;
   }
@@ -189,7 +189,7 @@ static int mem_gets(BIO *bio, char *buf, int size) {
   BUF_MEM *b = (BUF_MEM *)bio->ptr;
 
   BIO_clear_retry_flags(bio);
-  j = b->length;
+  j = (int)(b->length);
   if (size - 1 < j) {
     j = size - 1;
   }
@@ -312,13 +312,13 @@ long BIO_get_mem_data(BIO *bio, char **contents) {
 }
 
 int BIO_get_mem_ptr(BIO *bio, BUF_MEM **out) {
-  return BIO_ctrl(bio, BIO_C_GET_BUF_MEM_PTR, 0, (char *) out);
+  return (int)BIO_ctrl(bio, BIO_C_GET_BUF_MEM_PTR, 0, (char *) out);
 }
 
 int BIO_set_mem_buf(BIO *bio, BUF_MEM *b, int take_ownership) {
-  return BIO_ctrl(bio, BIO_C_SET_BUF_MEM, take_ownership, (char *) b);
+  return (int)BIO_ctrl(bio, BIO_C_SET_BUF_MEM, take_ownership, (char *) b);
 }
 
 int BIO_set_mem_eof_return(BIO *bio, int eof_value) {
-  return BIO_ctrl(bio, BIO_C_SET_BUF_MEM_EOF_RETURN, eof_value, NULL);
+  return (int)BIO_ctrl(bio, BIO_C_SET_BUF_MEM_EOF_RETURN, eof_value, NULL);
 }

--- a/src/crypto/bio/connect.c
+++ b/src/crypto/bio/connect.c
@@ -362,7 +362,7 @@ static int conn_read(BIO *bio, char *out, int out_len) {
   }
 
   bio_clear_socket_error();
-  ret = recv(bio->num, out, out_len, 0);
+  ret = (int)recv(bio->num, out, out_len, 0);
   BIO_clear_retry_flags(bio);
   if (ret <= 0) {
     if (bio_fd_should_retry(ret)) {
@@ -386,7 +386,7 @@ static int conn_write(BIO *bio, const char *in, int in_len) {
   }
 
   bio_clear_socket_error();
-  ret = send(bio->num, in, in_len, 0);
+  ret = (int)send(bio->num, in, in_len, 0);
   BIO_clear_retry_flags(bio);
   if (ret <= 0) {
     if (bio_fd_should_retry(ret)) {
@@ -517,11 +517,11 @@ static const BIO_METHOD methods_connectp = {
 const BIO_METHOD *BIO_s_connect(void) { return &methods_connectp; }
 
 int BIO_set_conn_hostname(BIO *bio, const char *name) {
-  return BIO_ctrl(bio, BIO_C_SET_CONNECT, 0, (void*) name);
+  return (int)BIO_ctrl(bio, BIO_C_SET_CONNECT, 0, (void*) name);
 }
 
 int BIO_set_conn_port(BIO *bio, const char *port_str) {
-  return BIO_ctrl(bio, BIO_C_SET_CONNECT, 1, (void*) port_str);
+  return (int)BIO_ctrl(bio, BIO_C_SET_CONNECT, 1, (void*) port_str);
 }
 
 int BIO_set_conn_int_port(BIO *bio, const int *port) {
@@ -531,11 +531,11 @@ int BIO_set_conn_int_port(BIO *bio, const int *port) {
 }
 
 int BIO_set_nbio(BIO *bio, int on) {
-  return BIO_ctrl(bio, BIO_C_SET_NBIO, on, NULL);
+  return (int)BIO_ctrl(bio, BIO_C_SET_NBIO, on, NULL);
 }
 
 int BIO_do_connect(BIO *bio) {
-  return BIO_ctrl(bio, BIO_C_DO_STATE_MACHINE, 0, NULL);
+  return (int)BIO_ctrl(bio, BIO_C_DO_STATE_MACHINE, 0, NULL);
 }
 
 #endif  // OPENSSL_TRUSTY

--- a/src/crypto/bio/fd.c
+++ b/src/crypto/bio/fd.c
@@ -158,7 +158,7 @@ static int fd_free(BIO *bio) {
 static int fd_read(BIO *b, char *out, int outl) {
   int ret = 0;
 
-  ret = BORINGSSL_READ(b->num, out, outl);
+  ret = (int)BORINGSSL_READ(b->num, out, outl);
   BIO_clear_retry_flags(b);
   if (ret <= 0) {
     if (bio_fd_should_retry(ret)) {
@@ -170,7 +170,7 @@ static int fd_read(BIO *b, char *out, int outl) {
 }
 
 static int fd_write(BIO *b, const char *in, int inl) {
-  int ret = BORINGSSL_WRITE(b->num, in, inl);
+  int ret = (int)BORINGSSL_WRITE(b->num, in, inl);
   BIO_clear_retry_flags(b);
   if (ret <= 0) {
     if (bio_fd_should_retry(ret)) {
@@ -254,7 +254,7 @@ static int fd_gets(BIO *bp, char *buf, int size) {
 
   ptr[0] = '\0';
 
-  return ptr - buf;
+  return (int)(ptr - buf);
 }
 
 static const BIO_METHOD methods_fdp = {
@@ -265,11 +265,11 @@ static const BIO_METHOD methods_fdp = {
 const BIO_METHOD *BIO_s_fd(void) { return &methods_fdp; }
 
 int BIO_set_fd(BIO *bio, int fd, int close_flag) {
-  return BIO_int_ctrl(bio, BIO_C_SET_FD, close_flag, fd);
+  return (int)BIO_int_ctrl(bio, BIO_C_SET_FD, close_flag, fd);
 }
 
 int BIO_get_fd(BIO *bio, int *out_fd) {
-  return BIO_ctrl(bio, BIO_C_GET_FD, 0, (char *) out_fd);
+  return (int)BIO_ctrl(bio, BIO_C_GET_FD, 0, (char *) out_fd);
 }
 
 #endif  // OPENSSL_TRUSTY

--- a/src/crypto/bio/file.c
+++ b/src/crypto/bio/file.c
@@ -163,7 +163,7 @@ static int file_write(BIO *b, const char *in, int inl) {
     return 0;
   }
 
-  ret = fwrite(in, inl, 1, (FILE *)b->ptr);
+  ret = (int)fwrite(in, inl, 1, (FILE *)b->ptr);
   if (ret > 0) {
     ret = inl;
   }
@@ -263,7 +263,7 @@ static int file_gets(BIO *bp, char *buf, int size) {
     buf[0] = 0;
     goto err;
   }
-  ret = strlen(buf);
+  ret = (int)strlen(buf);
 
 err:
   return ret;
@@ -281,30 +281,30 @@ const BIO_METHOD *BIO_s_file(void) { return &methods_filep; }
 
 
 int BIO_get_fp(BIO *bio, FILE **out_file) {
-  return BIO_ctrl(bio, BIO_C_GET_FILE_PTR, 0, (char*) out_file);
+  return (int)BIO_ctrl(bio, BIO_C_GET_FILE_PTR, 0, (char*) out_file);
 }
 
 int BIO_set_fp(BIO *bio, FILE *file, int close_flag) {
-  return BIO_ctrl(bio, BIO_C_SET_FILE_PTR, close_flag, (char *) file);
+  return (int)BIO_ctrl(bio, BIO_C_SET_FILE_PTR, close_flag, (char *) file);
 }
 
 int BIO_read_filename(BIO *bio, const char *filename) {
-  return BIO_ctrl(bio, BIO_C_SET_FILENAME, BIO_CLOSE | BIO_FP_READ,
+  return (int)BIO_ctrl(bio, BIO_C_SET_FILENAME, BIO_CLOSE | BIO_FP_READ,
                   (char *)filename);
 }
 
 int BIO_write_filename(BIO *bio, const char *filename) {
-  return BIO_ctrl(bio, BIO_C_SET_FILENAME, BIO_CLOSE | BIO_FP_WRITE,
+  return (int)BIO_ctrl(bio, BIO_C_SET_FILENAME, BIO_CLOSE | BIO_FP_WRITE,
                   (char *)filename);
 }
 
 int BIO_append_filename(BIO *bio, const char *filename) {
-  return BIO_ctrl(bio, BIO_C_SET_FILENAME, BIO_CLOSE | BIO_FP_APPEND,
+  return (int)BIO_ctrl(bio, BIO_C_SET_FILENAME, BIO_CLOSE | BIO_FP_APPEND,
                   (char *)filename);
 }
 
 int BIO_rw_filename(BIO *bio, const char *filename) {
-  return BIO_ctrl(bio, BIO_C_SET_FILENAME,
+  return (int)BIO_ctrl(bio, BIO_C_SET_FILENAME,
                   BIO_CLOSE | BIO_FP_READ | BIO_FP_WRITE, (char *)filename);
 }
 

--- a/src/crypto/bio/pair.c
+++ b/src/crypto/bio/pair.c
@@ -221,7 +221,7 @@ static int bio_read(BIO *bio, char *buf, int size_) {
     rest -= chunk;
   } while (rest);
 
-  return size;
+  return (int)size;
 }
 
 static int bio_write(BIO *bio, const char *buf, int num_) {
@@ -293,7 +293,7 @@ static int bio_write(BIO *bio, const char *buf, int num_) {
     buf += chunk;
   } while (rest);
 
-  return num;
+  return (int)num;
 }
 
 static int bio_make_pair(BIO *bio1, BIO *bio2, size_t writebuf1_len,
@@ -479,5 +479,5 @@ size_t BIO_ctrl_get_write_guarantee(BIO *bio) {
 }
 
 int BIO_shutdown_wr(BIO *bio) {
-  return BIO_ctrl(bio, BIO_C_SHUTDOWN_WR, 0, NULL);
+  return (int)BIO_ctrl(bio, BIO_C_SHUTDOWN_WR, 0, NULL);
 }

--- a/src/crypto/bio/socket.c
+++ b/src/crypto/bio/socket.c
@@ -101,7 +101,7 @@ static int sock_read(BIO *b, char *out, int outl) {
 #if defined(OPENSSL_WINDOWS)
   int ret = recv(b->num, out, outl, 0);
 #else
-  int ret = read(b->num, out, outl);
+  int ret = (int)read(b->num, out, outl);
 #endif
   BIO_clear_retry_flags(b);
   if (ret <= 0) {
@@ -119,7 +119,7 @@ static int sock_write(BIO *b, const char *in, int inl) {
 #if defined(OPENSSL_WINDOWS)
   ret = send(b->num, in, inl, 0);
 #else
-  ret = write(b->num, in, inl);
+  ret = (int)write(b->num, in, inl);
 #endif
   BIO_clear_retry_flags(b);
   if (ret <= 0) {

--- a/src/crypto/bytestring/cbs.c
+++ b/src/crypto/bytestring/cbs.c
@@ -133,7 +133,7 @@ int CBS_get_u24(CBS *cbs, uint32_t *out) {
   if (!cbs_get_u(cbs, &v, 3)) {
     return 0;
   }
-  *out = v;
+  *out = (uint32_t)v;
   return 1;
 }
 
@@ -142,7 +142,7 @@ int CBS_get_u32(CBS *cbs, uint32_t *out) {
   if (!cbs_get_u(cbs, &v, 4)) {
     return 0;
   }
-  *out = v;
+  *out = (uint32_t)v;
   return 1;
 }
 

--- a/src/crypto/cipher_extra/e_chacha20poly1305.c
+++ b/src/crypto/cipher_extra/e_chacha20poly1305.c
@@ -147,7 +147,7 @@ static int chacha20_poly1305_seal_scatter(
   // encrypted byte-by-byte first.
   if (extra_in_len) {
     static const size_t kChaChaBlockSize = 64;
-    uint32_t block_counter = 1 + (in_len / kChaChaBlockSize);
+    uint32_t block_counter = 1 + (uint32_t)(in_len / kChaChaBlockSize);
     size_t offset = in_len % kChaChaBlockSize;
     uint8_t block[64 /* kChaChaBlockSize */];
 

--- a/src/crypto/cipher_extra/e_tls.c
+++ b/src/crypto/cipher_extra/e_tls.c
@@ -209,7 +209,7 @@ static int aead_tls_seal_scatter(const EVP_AEAD_CTX *ctx, uint8_t *out,
   size_t tag_len = early_mac_len;
 
   if (!EVP_EncryptUpdate(&tls_ctx->cipher_ctx, out_tag + tag_len, &len,
-                         mac + tag_len, mac_len - tag_len)) {
+                         mac + tag_len, (int)(mac_len - tag_len))) {
     return 0;
   }
   tag_len += len;

--- a/src/crypto/cmac/cmac.c
+++ b/src/crypto/cmac/cmac.c
@@ -244,7 +244,7 @@ int CMAC_Update(CMAC_CTX *ctx, const uint8_t *in, size_t in_len) {
   }
 
   OPENSSL_memcpy(ctx->block, in, in_len);
-  ctx->block_used = in_len;
+  ctx->block_used = (unsigned int)in_len;
 
   return 1;
 }

--- a/src/crypto/conf/conf.c
+++ b/src/crypto/conf/conf.c
@@ -222,7 +222,7 @@ static int str_copy(CONF *conf, char *section, char **pto, char *from) {
     return 0;
   }
 
-  len = strlen(from) + 1;
+  len = (int)(strlen(from) + 1);
   if (!BUF_MEM_grow(buf, len)) {
     goto err;
   }
@@ -572,7 +572,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *out_error_line) {
     *p = '\0';
     BIO_gets(in, p, CONFBUFSIZE - 1);
     p[CONFBUFSIZE - 1] = '\0';
-    ii = i = strlen(p);
+    ii = i = (int)strlen(p);
     if (i == 0 && !again) {
       break;
     }
@@ -797,7 +797,7 @@ int CONF_parse_list(const char *list, char sep, int remove_whitespace,
           tmpend--;
         }
       }
-      ret = list_cb(lstart, tmpend - lstart + 1, arg);
+      ret = list_cb(lstart, (int)(tmpend - lstart + 1), arg);
     }
     if (ret <= 0) {
       return ret;

--- a/src/crypto/curve25519/spake25519.c
+++ b/src/crypto/curve25519/spake25519.c
@@ -330,7 +330,7 @@ static const scalar kOrder = {{0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
 static void scalar_cmov(scalar *dest, const scalar *src, crypto_word_t mask) {
   for (size_t i = 0; i < 8; i++) {
     dest->words[i] =
-        constant_time_select_w(mask, src->words[i], dest->words[i]);
+        (uint32_t)constant_time_select_w(mask, src->words[i], dest->words[i]);
   }
 }
 

--- a/src/crypto/dsa/dsa.c
+++ b/src/crypto/dsa/dsa.c
@@ -223,7 +223,7 @@ int DSA_generate_parameters_ex(DSA *dsa, unsigned bits, const uint8_t *seed_in,
   const EVP_MD *evpmd;
 
   evpmd = (bits >= 2048) ? EVP_sha256() : EVP_sha1();
-  qsize = EVP_MD_size(evpmd);
+  qsize = (unsigned)EVP_MD_size(evpmd);
 
   if (bits < 512) {
     bits = 512;
@@ -859,7 +859,7 @@ int DSA_size(const DSA *dsa) {
   if (ret < value_len) {
     return 0;
   }
-  return ret;
+  return (int)ret;
 }
 
 static int dsa_sign_setup(const DSA *dsa, BN_CTX *ctx, BIGNUM **out_kinv,

--- a/src/crypto/ec_extra/ec_asn1.c
+++ b/src/crypto/ec_extra/ec_asn1.c
@@ -7,7 +7,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -531,7 +531,7 @@ int i2o_ECPublicKey(const EC_KEY *key, uint8_t **outp) {
 
   if (outp == NULL || buf_len == 0) {
     // out == NULL => just return the length of the octet string
-    return buf_len;
+    return (int)buf_len;
   }
 
   if (*outp == NULL) {
@@ -555,5 +555,5 @@ int i2o_ECPublicKey(const EC_KEY *key, uint8_t **outp) {
   if (!new_buffer) {
     *outp += buf_len;
   }
-  return buf_len;
+  return (int)buf_len;
 }

--- a/src/crypto/err/err.c
+++ b/src/crypto/err/err.c
@@ -852,6 +852,6 @@ void ERR_restore_state(const ERR_SAVE_STATE *state) {
   for (size_t i = 0; i < state->num_errors; i++) {
     err_copy(&dst->errors[i], &state->errors[i]);
   }
-  dst->top = state->num_errors - 1;
+  dst->top = (unsigned int)(state->num_errors - 1);
   dst->bottom = ERR_NUM_ERRORS - 1;
 }

--- a/src/crypto/evp/p_ec_asn1.c
+++ b/src/crypto/evp/p_ec_asn1.c
@@ -9,7 +9,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -189,7 +189,7 @@ static int eckey_priv_encode(CBB *out, const EVP_PKEY *key) {
 }
 
 static int int_ec_size(const EVP_PKEY *pkey) {
-  return ECDSA_size(pkey->pkey.ec);
+  return (int)ECDSA_size(pkey->pkey.ec);
 }
 
 static int ec_bits(const EVP_PKEY *pkey) {

--- a/src/crypto/evp/p_rsa.c
+++ b/src/crypto/evp/p_rsa.c
@@ -188,7 +188,7 @@ static int pkey_rsa_sign(EVP_PKEY_CTX *ctx, uint8_t *sig, size_t *siglen,
     unsigned out_len;
     switch (rctx->pad_mode) {
       case RSA_PKCS1_PADDING:
-        if (!RSA_sign(EVP_MD_type(rctx->md), tbs, tbslen, sig, &out_len, rsa)) {
+        if (!RSA_sign(EVP_MD_type(rctx->md), tbs, (unsigned int)tbslen, sig, &out_len, rsa)) {
           return 0;
         }
         *siglen = out_len;

--- a/src/crypto/evp/print.c
+++ b/src/crypto/evp/print.c
@@ -93,7 +93,7 @@ static int bn_print(BIO *bp, const char *number, const BIGNUM *num,
                    (BN_is_negative(num)) ? " (Negative)" : "") <= 0) {
       return 0;
     }
-    int n = BN_bn2bin(num, &buf[1]);
+    int n = (int)BN_bn2bin(num, &buf[1]);
 
     if (buf[1] & 0x80) {
       n++;

--- a/src/crypto/evp/sign.c
+++ b/src/crypto/evp/sign.c
@@ -97,7 +97,7 @@ int EVP_SignFinal(const EVP_MD_CTX *ctx, uint8_t *sig,
       !EVP_PKEY_sign(pkctx, sig, &sig_len, m, m_len)) {
     goto out;
   }
-  *out_sig_len = sig_len;
+  *out_sig_len = (unsigned int)sig_len;
   ret = 1;
 
 out:

--- a/src/crypto/ex_data.c
+++ b/src/crypto/ex_data.c
@@ -156,7 +156,7 @@ int CRYPTO_get_ex_new_index(CRYPTO_EX_DATA_CLASS *ex_data_class, int *out_index,
     goto err;
   }
 
-  *out_index = sk_CRYPTO_EX_DATA_FUNCS_num(ex_data_class->meth) - 1 +
+  *out_index = (int)sk_CRYPTO_EX_DATA_FUNCS_num(ex_data_class->meth) - 1 +
                ex_data_class->num_reserved;
   ret = 1;
 
@@ -176,7 +176,7 @@ int CRYPTO_set_ex_data(CRYPTO_EX_DATA *ad, int index, void *val) {
     }
   }
 
-  n = sk_void_num(ad->sk);
+  n = (int)sk_void_num(ad->sk);
 
   // Add NULL values until the stack is long enough.
   for (i = n; i <= index; i++) {
@@ -246,8 +246,8 @@ void CRYPTO_free_ex_data(CRYPTO_EX_DATA_CLASS *ex_data_class, void *obj,
     CRYPTO_EX_DATA_FUNCS *func_pointer =
         sk_CRYPTO_EX_DATA_FUNCS_value(func_pointers, i);
     if (func_pointer->free_func) {
-      void *ptr = CRYPTO_get_ex_data(ad, i + ex_data_class->num_reserved);
-      func_pointer->free_func(obj, ptr, ad, i + ex_data_class->num_reserved,
+      void *ptr = CRYPTO_get_ex_data(ad, (int)(i + ex_data_class->num_reserved));
+      func_pointer->free_func(obj, ptr, ad, (int)(i + ex_data_class->num_reserved),
                               func_pointer->argl, func_pointer->argp);
     }
   }

--- a/src/crypto/fipsmodule/aes/aes_nohw.c
+++ b/src/crypto/fipsmodule/aes/aes_nohw.c
@@ -1193,7 +1193,7 @@ void aes_nohw_ctr32_encrypt_blocks(const uint8_t *in, uint8_t *out,
   for (;;) {
     // Update counters.
     for (size_t i = 0; i < AES_NOHW_BATCH_SIZE; i++) {
-      ivs.u32[4 * i + 3] = CRYPTO_bswap4(ctr + i);
+      ivs.u32[4 * i + 3] = CRYPTO_bswap4(ctr + (uint32_t)i);
     }
 
     size_t todo = blocks >= AES_NOHW_BATCH_SIZE ? AES_NOHW_BATCH_SIZE : blocks;

--- a/src/crypto/fipsmodule/aes/key_wrap.c
+++ b/src/crypto/fipsmodule/aes/key_wrap.c
@@ -161,7 +161,7 @@ static const uint8_t kPaddingConstant[4] = {0xa6, 0x59, 0x59, 0xa6};
 int AES_wrap_key_padded(const AES_KEY *key, uint8_t *out, size_t *out_len,
                         size_t max_out, const uint8_t *in, size_t in_len) {
   // See https://tools.ietf.org/html/rfc5649#section-4.1
-  const uint32_t in_len32_be = CRYPTO_bswap4(in_len);
+  const uint32_t in_len32_be = CRYPTO_bswap4((uint32_t)in_len);
   const uint64_t in_len64 = in_len;
   const size_t padded_len = (in_len + 7) & ~7;
 

--- a/src/crypto/fipsmodule/bn/bn.c
+++ b/src/crypto/fipsmodule/bn/bn.c
@@ -289,8 +289,8 @@ void bn_set_static_words(BIGNUM *bn, const BN_ULONG *words, size_t num) {
   }
   bn->d = (BN_ULONG *)words;
 
-  bn->width = num;
-  bn->dmax = num;
+  bn->width = (int)num;
+  bn->dmax = (int)num;
   bn->neg = 0;
   bn->flags |= BN_FLG_STATIC_DATA;
 }
@@ -400,7 +400,7 @@ int bn_resize_words(BIGNUM *bn, size_t words) {
     }
     OPENSSL_memset(bn->d + bn->width, 0,
                    (words - bn->width) * sizeof(BN_ULONG));
-    bn->width = words;
+    bn->width = (int)words;
     return 1;
   }
 
@@ -409,7 +409,7 @@ int bn_resize_words(BIGNUM *bn, size_t words) {
     OPENSSL_PUT_ERROR(BN, BN_R_BIGNUM_TOO_LONG);
     return 0;
   }
-  bn->width = words;
+  bn->width = (int)words;
   return 1;
 }
 

--- a/src/crypto/fipsmodule/bn/bytes.c
+++ b/src/crypto/fipsmodule/bn/bytes.c
@@ -131,7 +131,7 @@ BIGNUM *BN_le2bn(const uint8_t *in, size_t len, BIGNUM *ret) {
     BN_free(bn);
     return NULL;
   }
-  ret->width = num_words;
+  ret->width = (int)num_words;
 
   // Make sure the top bytes will be zeroed.
   ret->d[num_words - 1] = 0;

--- a/src/crypto/fipsmodule/bn/div.c
+++ b/src/crypto/fipsmodule/bn/div.c
@@ -552,7 +552,7 @@ static BIGNUM *bn_scratch_space_from_ctx(size_t width, BN_CTX *ctx) {
     return NULL;
   }
   ret->neg = 0;
-  ret->width = width;
+  ret->width = (int)width;
   return ret;
 }
 

--- a/src/crypto/fipsmodule/bn/div_extra.c
+++ b/src/crypto/fipsmodule/bn/div_extra.c
@@ -70,7 +70,7 @@ uint16_t bn_mod_u16_consttime(const BIGNUM *bn, uint16_t d) {
   // This operation is not constant-time, but |p| and |d| are public values.
   // Note that |p| is at most 16, so the computation fits in |uint64_t|.
   assert(p <= 16);
-  uint32_t m = ((UINT64_C(1) << (32 + p)) + d - 1) / d;
+  uint32_t m = (uint32_t)(((UINT64_C(1) << (32 + p)) + d - 1) / d);
 
   uint16_t ret = 0;
   for (int i = bn->width - 1; i >= 0; i--) {

--- a/src/crypto/fipsmodule/bn/exponentiation.c
+++ b/src/crypto/fipsmodule/bn/exponentiation.c
@@ -735,7 +735,7 @@ void bn_mod_exp_mont_small(BN_ULONG *r, const BN_ULONG *a, size_t num,
     bn_from_montgomery_small(r, num, mont->RR.d, num, mont);
     return;
   }
-  unsigned bits = BN_num_bits_word(p[num_p - 1]) + (num_p - 1) * BN_BITS2;
+  unsigned bits = (unsigned)(BN_num_bits_word(p[num_p - 1]) + (num_p - 1) * BN_BITS2);
   assert(bits != 0);
 
   // We exponentiate by looking at sliding windows of the exponent and

--- a/src/crypto/fipsmodule/bn/gcd_extra.c
+++ b/src/crypto/fipsmodule/bn/gcd_extra.c
@@ -240,7 +240,7 @@ int bn_mod_inverse_consttime(BIGNUM *r, int *out_no_inverse, const BIGNUM *a,
 
   // Each loop iteration halves at least one of |u| and |v|. Thus we need at
   // most the combined bit width of inputs for at least one value to be zero.
-  unsigned a_bits = a_width * BN_BITS2, n_bits = n_width * BN_BITS2;
+  unsigned a_bits = (unsigned)(a_width * BN_BITS2), n_bits = (unsigned)(n_width * BN_BITS2);
   unsigned num_iters = a_bits + n_bits;
   if (num_iters < a_bits) {
     OPENSSL_PUT_ERROR(BN, BN_R_BIGNUM_TOO_LONG);

--- a/src/crypto/fipsmodule/bn/random.c
+++ b/src/crypto/fipsmodule/bn/random.c
@@ -328,7 +328,7 @@ int bn_rand_secret_range(BIGNUM *r, int *out_is_uniform, BN_ULONG min_inclusive,
   assert(bn_in_range_words(r->d, min_inclusive, max_exclusive->d, words));
 
   r->neg = 0;
-  r->width = words;
+  r->width = (int)words;
   return 1;
 }
 

--- a/src/crypto/fipsmodule/cipher/e_aes.c
+++ b/src/crypto/fipsmodule/cipher/e_aes.c
@@ -293,7 +293,7 @@ ctr128_f aes_ctr_set_key(AES_KEY *aes_key, GCM128_KEY *gcm_key,
                          block128_f *out_block, const uint8_t *key,
                          size_t key_bytes) {
   if (hwaes_capable()) {
-    aes_hw_set_encrypt_key(key, key_bytes * 8, aes_key);
+    aes_hw_set_encrypt_key(key, (int)(key_bytes * 8), aes_key);
     if (gcm_key != NULL) {
       CRYPTO_gcm128_init_key(gcm_key, aes_key, aes_hw_encrypt, 1);
     }
@@ -304,7 +304,7 @@ ctr128_f aes_ctr_set_key(AES_KEY *aes_key, GCM128_KEY *gcm_key,
   }
 
   if (vpaes_capable()) {
-    vpaes_set_encrypt_key(key, key_bytes * 8, aes_key);
+    vpaes_set_encrypt_key(key, (int)(key_bytes * 8), aes_key);
     if (out_block) {
       *out_block = vpaes_encrypt;
     }
@@ -321,7 +321,7 @@ ctr128_f aes_ctr_set_key(AES_KEY *aes_key, GCM128_KEY *gcm_key,
 #endif
   }
 
-  aes_nohw_set_encrypt_key(key, key_bytes * 8, aes_key);
+  aes_nohw_set_encrypt_key(key, (unsigned int)(key_bytes * 8), aes_key);
   if (gcm_key != NULL) {
     CRYPTO_gcm128_init_key(gcm_key, aes_key, aes_nohw_encrypt, 0);
   }
@@ -580,7 +580,7 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, uint8_t *out, const uint8_t *in,
         }
       }
     }
-    return len;
+    return (int)len;
   } else {
     if (!ctx->encrypt) {
       if (gctx->taglen < 0 ||

--- a/src/crypto/fipsmodule/des/des.c
+++ b/src/crypto/fipsmodule/des/des.c
@@ -314,7 +314,7 @@ void DES_set_key(const DES_cblock *key, DES_key_schedule *schedule) {
   PERM_OP(d, c, t, 1, 0x55555555L);
   PERM_OP(c, d, t, 8, 0x00ff00ffL);
   PERM_OP(d, c, t, 1, 0x55555555L);
-  d = (((d & 0x000000ffL) << 16L) | (d & 0x0000ff00L) |
+  d = (uint32_t)(((d & 0x000000ffL) << 16L) | (d & 0x0000ff00L) |
        ((d & 0x00ff0000L) >> 16L) | ((c & 0xf0000000L) >> 4L));
   c &= 0x0fffffffL;
 

--- a/src/crypto/fipsmodule/dh/dh.c
+++ b/src/crypto/fipsmodule/dh/dh.c
@@ -353,7 +353,7 @@ int DH_compute_key(unsigned char *out, const BIGNUM *peers_key, DH *dh) {
   int ret = -1;
   BIGNUM *shared_key = BN_CTX_get(ctx);
   if (shared_key && dh_compute_key(dh, shared_key, peers_key, ctx)) {
-    ret = BN_bn2bin(shared_key, out);
+    ret = (int)BN_bn2bin(shared_key, out);
   }
 
   BN_CTX_end(ctx);

--- a/src/crypto/fipsmodule/ec/p256.c
+++ b/src/crypto/fipsmodule/ec/p256.c
@@ -498,12 +498,12 @@ static void ec_GFp_nistp256_point_mul(const EC_GROUP *group, EC_RAW_POINT *r,
 
     // do other additions every 5 doublings
     if (i % 5 == 0) {
-      crypto_word_t bits = fiat_p256_get_bit(scalar->bytes, i + 4) << 5;
-      bits |= fiat_p256_get_bit(scalar->bytes, i + 3) << 4;
-      bits |= fiat_p256_get_bit(scalar->bytes, i + 2) << 3;
-      bits |= fiat_p256_get_bit(scalar->bytes, i + 1) << 2;
-      bits |= fiat_p256_get_bit(scalar->bytes, i) << 1;
-      bits |= fiat_p256_get_bit(scalar->bytes, i - 1);
+      crypto_word_t bits = fiat_p256_get_bit(scalar->bytes, (int)i + 4) << 5;
+      bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 3) << 4;
+      bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 2) << 3;
+      bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 1) << 2;
+      bits |= fiat_p256_get_bit(scalar->bytes, (int)i) << 1;
+      bits |= fiat_p256_get_bit(scalar->bytes, (int)i - 1);
       crypto_word_t sign, digit;
       ec_GFp_nistp_recode_scalar_bits(&sign, &digit, bits);
 
@@ -543,10 +543,10 @@ static void ec_GFp_nistp256_point_mul_base(const EC_GROUP *group,
     }
 
     // First, look 32 bits upwards.
-    crypto_word_t bits = fiat_p256_get_bit(scalar->bytes, i + 224) << 3;
-    bits |= fiat_p256_get_bit(scalar->bytes, i + 160) << 2;
-    bits |= fiat_p256_get_bit(scalar->bytes, i + 96) << 1;
-    bits |= fiat_p256_get_bit(scalar->bytes, i + 32);
+    crypto_word_t bits = fiat_p256_get_bit(scalar->bytes, (int)i + 224) << 3;
+    bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 160) << 2;
+    bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 96) << 1;
+    bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 32);
     // Select the point to add, in constant time.
     fiat_p256_select_point_affine((fiat_p256_limb_t)bits, 15,
                                   fiat_p256_g_pre_comp[1], tmp);
@@ -562,10 +562,10 @@ static void ec_GFp_nistp256_point_mul_base(const EC_GROUP *group,
     }
 
     // Second, look at the current position.
-    bits = fiat_p256_get_bit(scalar->bytes, i + 192) << 3;
-    bits |= fiat_p256_get_bit(scalar->bytes, i + 128) << 2;
-    bits |= fiat_p256_get_bit(scalar->bytes, i + 64) << 1;
-    bits |= fiat_p256_get_bit(scalar->bytes, i);
+    bits = fiat_p256_get_bit(scalar->bytes, (int)i + 192) << 3;
+    bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 128) << 2;
+    bits |= fiat_p256_get_bit(scalar->bytes, (int)i + 64) << 1;
+    bits |= fiat_p256_get_bit(scalar->bytes, (int)i);
     // Select the point to add, in constant time.
     fiat_p256_select_point_affine((fiat_p256_limb_t)bits, 15,
                                   fiat_p256_g_pre_comp[0], tmp);

--- a/src/crypto/fipsmodule/ec/wnaf.c
+++ b/src/crypto/fipsmodule/ec/wnaf.c
@@ -139,7 +139,7 @@ void ec_compute_wNAF(const EC_GROUP *group, int8_t *out,
     // afterwards.
     window_val >>= 1;
     window_val +=
-        bit * bn_is_bit_set_words(scalar->words, group->order.width, j + w + 1);
+        bit * bn_is_bit_set_words(scalar->words, group->order.width, (unsigned int)(j + w + 1));
     assert(window_val <= next_bit);
   }
 

--- a/src/crypto/fipsmodule/rand/ctrdrbg.c
+++ b/src/crypto/fipsmodule/rand/ctrdrbg.c
@@ -167,7 +167,7 @@ int CTR_DRBG_generate(CTR_DRBG_STATE *drbg, uint8_t *out, size_t out_len,
       OPENSSL_memset(out, 0, todo);
       ctr32_add(drbg, 1);
       drbg->ctr(out, out, num_blocks, &drbg->ks, drbg->counter.bytes);
-      ctr32_add(drbg, num_blocks - 1);
+      ctr32_add(drbg, (uint32_t)(num_blocks - 1));
     } else {
       for (size_t i = 0; i < todo; i += AES_BLOCK_SIZE) {
         ctr32_add(drbg, 1);

--- a/src/crypto/fipsmodule/rsa/padding.c
+++ b/src/crypto/fipsmodule/rsa/padding.c
@@ -507,7 +507,7 @@ int RSA_verify_PKCS1_PSS_mgf1(const RSA *rsa, const uint8_t *mHash,
   //	-2	salt length is autorecovered from signature
   //	-N	reserved
   if (sLen == -1) {
-    sLen = hLen;
+    sLen = (int)hLen;
   } else if (sLen == -2) {
     sLen = -2;
   } else if (sLen < -2) {
@@ -534,7 +534,7 @@ int RSA_verify_PKCS1_PSS_mgf1(const RSA *rsa, const uint8_t *mHash,
     OPENSSL_PUT_ERROR(RSA, RSA_R_LAST_OCTET_INVALID);
     goto err;
   }
-  maskedDBLen = emLen - hLen - 1;
+  maskedDBLen = emLen - (int)hLen - 1;
   H = EM + maskedDBLen;
   DB = OPENSSL_malloc(maskedDBLen);
   if (!DB) {

--- a/src/crypto/fipsmodule/rsa/rsa.c
+++ b/src/crypto/fipsmodule/rsa/rsa.c
@@ -300,7 +300,7 @@ int RSA_public_encrypt(size_t flen, const uint8_t *from, uint8_t *to, RSA *rsa,
     OPENSSL_PUT_ERROR(RSA, ERR_R_OVERFLOW);
     return -1;
   }
-  return out_len;
+  return (int)out_len;
 }
 
 int RSA_sign_raw(RSA *rsa, size_t *out_len, uint8_t *out, size_t max_out,
@@ -324,7 +324,7 @@ int RSA_private_encrypt(size_t flen, const uint8_t *from, uint8_t *to, RSA *rsa,
     OPENSSL_PUT_ERROR(RSA, ERR_R_OVERFLOW);
     return -1;
   }
-  return out_len;
+  return (int)out_len;
 }
 
 int RSA_decrypt(RSA *rsa, size_t *out_len, uint8_t *out, size_t max_out,
@@ -348,7 +348,7 @@ int RSA_private_decrypt(size_t flen, const uint8_t *from, uint8_t *to, RSA *rsa,
     OPENSSL_PUT_ERROR(RSA, ERR_R_OVERFLOW);
     return -1;
   }
-  return out_len;
+  return (int)out_len;
 }
 
 int RSA_public_decrypt(size_t flen, const uint8_t *from, uint8_t *to, RSA *rsa,
@@ -363,15 +363,15 @@ int RSA_public_decrypt(size_t flen, const uint8_t *from, uint8_t *to, RSA *rsa,
     OPENSSL_PUT_ERROR(RSA, ERR_R_OVERFLOW);
     return -1;
   }
-  return out_len;
+  return (int)out_len;
 }
 
 unsigned RSA_size(const RSA *rsa) {
   if (rsa->meth->size) {
-    return rsa->meth->size(rsa);
+    return (unsigned)(rsa->meth->size(rsa));
   }
 
-  return rsa_default_size(rsa);
+  return (unsigned)rsa_default_size(rsa);
 }
 
 int RSA_is_opaque(const RSA *rsa) {
@@ -497,7 +497,7 @@ int RSA_add_pkcs1_prefix(uint8_t **out_msg, size_t *out_msg_len,
     unsigned signed_msg_len;
     uint8_t *signed_msg;
 
-    signed_msg_len = prefix_len + digest_len;
+    signed_msg_len = (unsigned)(prefix_len + digest_len);
     if (signed_msg_len < prefix_len) {
       OPENSSL_PUT_ERROR(RSA, RSA_R_TOO_LONG);
       return 0;
@@ -544,7 +544,7 @@ int RSA_sign(int hash_nid, const uint8_t *digest, unsigned digest_len,
     goto err;
   }
 
-  *out_len = size_t_out_len;
+  *out_len = (unsigned)size_t_out_len;
   ret = 1;
 
 err:

--- a/src/crypto/fipsmodule/rsa/rsa_impl.c
+++ b/src/crypto/fipsmodule/rsa/rsa_impl.c
@@ -388,7 +388,7 @@ static BN_BLINDING *rsa_blinding_get(RSA *rsa, unsigned *index_used,
       OPENSSL_memchr(rsa->blindings_inuse, 0, rsa->num_blindings);
   if (free_inuse_flag != NULL) {
     *free_inuse_flag = 1;
-    *index_used = free_inuse_flag - rsa->blindings_inuse;
+    *index_used = (unsigned int)(free_inuse_flag - rsa->blindings_inuse);
     ret = rsa->blindings[*index_used];
     goto out;
   }

--- a/src/crypto/fipsmodule/tls/kdf.c
+++ b/src/crypto/fipsmodule/tls/kdf.c
@@ -106,7 +106,7 @@ static int tls1_P_hash(uint8_t *out, size_t out_len,
 
     // XOR the result into |out|.
     if (len > out_len) {
-      len = out_len;
+      len = (unsigned)out_len;
     }
     for (unsigned i = 0; i < len; i++) {
       out[i] ^= hmac[i];

--- a/src/crypto/obj/obj.c
+++ b/src/crypto/obj/obj.c
@@ -402,7 +402,7 @@ static ASN1_OBJECT *create_object_with_text_oid(int (*get_nid)(void),
   }
 
   ASN1_OBJECT *ret = ASN1_OBJECT_create(get_nid ? get_nid() : NID_undef, buf,
-                                        len, short_name, long_name);
+                                        (int)len, short_name, long_name);
   OPENSSL_free(buf);
   return ret;
 }

--- a/src/crypto/pem/pem_lib.c
+++ b/src/crypto/pem/pem_lib.c
@@ -106,7 +106,7 @@ void PEM_dek_info(char *buf, const char *type, int len, char *str)
     OPENSSL_strlcat(buf, "DEK-Info: ", PEM_BUFSIZE);
     OPENSSL_strlcat(buf, type, PEM_BUFSIZE);
     OPENSSL_strlcat(buf, ",", PEM_BUFSIZE);
-    j = strlen(buf);
+    j = (int)strlen(buf);
     if (j + (len * 2) + 1 > PEM_BUFSIZE)
         return;
     for (i = 0; i < len; i++) {
@@ -525,14 +525,14 @@ int PEM_write_bio(BIO *bp, const char *name, const char *header,
     int reason = ERR_R_BUF_LIB;
 
     EVP_EncodeInit(&ctx);
-    nlen = strlen(name);
+    nlen = (int)strlen(name);
 
     if ((BIO_write(bp, "-----BEGIN ", 11) != 11) ||
         (BIO_write(bp, name, nlen) != nlen) ||
         (BIO_write(bp, "-----\n", 6) != 6))
         goto err;
 
-    i = strlen(header);
+    i = (int)strlen(header);
     if (i > 0) {
         if ((BIO_write(bp, header, i) != i) || (BIO_write(bp, "\n", 1) != 1))
             goto err;
@@ -621,7 +621,7 @@ int PEM_read_bio(BIO *bp, char **name, char **header, unsigned char **data,
         buf[++i] = '\0';
 
         if (strncmp(buf, "-----BEGIN ", 11) == 0) {
-            i = strlen(&(buf[11]));
+            i = (int)strlen(&(buf[11]));
 
             if (strncmp(&(buf[11 + i - 6]), "-----\n", 6) != 0)
                 continue;
@@ -715,7 +715,7 @@ int PEM_read_bio(BIO *bp, char **name, char **header, unsigned char **data,
         dataB = tmpB;
         bl = hl;
     }
-    i = strlen(nameB->data);
+    i = (int)strlen(nameB->data);
     if ((strncmp(buf, "-----END ", 9) != 0) ||
         (strncmp(nameB->data, &(buf[9]), i) != 0) ||
         (strncmp(&(buf[9 + i]), "-----\n", 6) != 0)) {
@@ -765,5 +765,5 @@ int PEM_def_callback(char *buf, int size, int rwflag, void *userdata)
         return 0;
     }
     OPENSSL_strlcpy(buf, userdata, (size_t)size);
-    return len;
+    return (int)len;
 }

--- a/src/crypto/pkcs8/pkcs8.c
+++ b/src/crypto/pkcs8/pkcs8.c
@@ -513,7 +513,7 @@ int PKCS8_marshal_encrypted_private_key(CBB *out, int pbe_nid,
   int n1, n2;
   if (!CBB_add_asn1(&epki, &ciphertext, CBS_ASN1_OCTETSTRING) ||
       !CBB_reserve(&ciphertext, &ptr, max_out) ||
-      !EVP_CipherUpdate(&ctx, ptr, &n1, plaintext, plaintext_len) ||
+      !EVP_CipherUpdate(&ctx, ptr, &n1, plaintext, (int)plaintext_len) ||
       !EVP_CipherFinal_ex(&ctx, ptr + n1, &n2) ||
       !CBB_did_write(&ciphertext, n1 + n2) ||
       !CBB_flush(out)) {

--- a/src/crypto/pkcs8/pkcs8_x509.c
+++ b/src/crypto/pkcs8/pkcs8_x509.c
@@ -498,7 +498,7 @@ static int PKCS12_handle_safe_bag(CBS *safe_bag, struct pkcs12_context *ctx) {
       return 0;
     }
     int ok = friendly_name_len == 0 ||
-             X509_alias_set1(x509, friendly_name, friendly_name_len);
+             X509_alias_set1(x509, friendly_name, (int)friendly_name_len);
     OPENSSL_free(friendly_name);
     if (!ok ||
         0 == sk_X509_push(ctx->out_certs, x509)) {
@@ -735,7 +735,7 @@ int PKCS12_get_key_and_certs(EVP_PKEY **out_key, STACK_OF(X509) *out_certs,
 
     int mac_ok;
     if (!pkcs12_check_mac(&mac_ok, ctx.password, ctx.password_len, &salt,
-                          iterations, md, &authsafes, &expected_mac)) {
+                          (unsigned int)iterations, md, &authsafes, &expected_mac)) {
       goto err;
     }
     if (!mac_ok && ctx.password_len == 0) {
@@ -746,7 +746,7 @@ int PKCS12_get_key_and_certs(EVP_PKEY **out_key, STACK_OF(X509) *out_certs,
       // code, tries both options. We match this behavior.
       ctx.password = ctx.password != NULL ? NULL : "";
       if (!pkcs12_check_mac(&mac_ok, ctx.password, ctx.password_len, &salt,
-                            iterations, md, &authsafes, &expected_mac)) {
+                            (unsigned int)iterations, md, &authsafes, &expected_mac)) {
         goto err;
       }
     }
@@ -828,7 +828,7 @@ PKCS12* d2i_PKCS12_bio(BIO *bio, PKCS12 **out_p12) {
   }
 
   for (;;) {
-    int n = BIO_read(bio, &buf->data[used], buf->length - used);
+    int n = BIO_read(bio, &buf->data[used], (int)(buf->length - used));
     if (n < 0) {
       if (used == 0) {
         goto out;
@@ -1136,7 +1136,7 @@ static int add_encrypted_data(CBB *out, int pbe_nid, const char *password,
   uint8_t *ptr;
   int n1, n2;
   if (!CBB_reserve(&encrypted_content, &ptr, max_out) ||
-      !EVP_CipherUpdate(&ctx, ptr, &n1, in, in_len) ||
+      !EVP_CipherUpdate(&ctx, ptr, &n1, in, (int)in_len) ||
       !EVP_CipherFinal_ex(&ctx, ptr + n1, &n2) ||
       !CBB_did_write(&encrypted_content, n1 + n2) ||
       !CBB_flush(out)) {

--- a/src/crypto/trust_token/trust_token.c
+++ b/src/crypto/trust_token/trust_token.c
@@ -597,7 +597,7 @@ static int add_cbor_int_with_type(CBB *cbb, uint8_t major_type,
     return CBB_add_u8(cbb, 0x19 | major_type) && CBB_add_u16(cbb, value);
   }
   if (value <= 0xffffffff) {
-    return CBB_add_u8(cbb, 0x1a | major_type) && CBB_add_u32(cbb, value);
+    return CBB_add_u8(cbb, 0x1a | major_type) && CBB_add_u32(cbb, (uint32_t)value);
   }
   if (value <= 0xffffffffffffffff) {
     return CBB_add_u8(cbb, 0x1b | major_type) && CBB_add_u64(cbb, value);

--- a/src/crypto/x509/a_sign.c
+++ b/src/crypto/x509/a_sign.c
@@ -113,7 +113,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
         OPENSSL_free(signature->data);
     signature->data = buf_out;
     buf_out = NULL;
-    signature->length = outl;
+    signature->length = (int)outl;
     /*
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
@@ -124,5 +124,5 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it,
     EVP_MD_CTX_cleanup(ctx);
     OPENSSL_free(buf_in);
     OPENSSL_free(buf_out);
-    return (outl);
+    return (int)(outl);
 }

--- a/src/crypto/x509/asn1_gen.c
+++ b/src/crypto/x509/asn1_gen.c
@@ -220,7 +220,7 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
          * Work out new length with IMPLICIT tag: ignore constructed because
          * it will mess up if indefinite length
          */
-        len = ASN1_object_size(0, hdr_len, asn1_tags.imp_tag);
+        len = ASN1_object_size(0, (int)hdr_len, asn1_tags.imp_tag);
     } else
         len = cpy_len;
 
@@ -249,7 +249,7 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
 
     for (i = 0, etmp = asn1_tags.exp_list; i < asn1_tags.exp_count;
          i++, etmp++) {
-        ASN1_put_object(&p, etmp->exp_constructed, etmp->exp_len,
+        ASN1_put_object(&p, etmp->exp_constructed, (int)(etmp->exp_len),
                         etmp->exp_tag, etmp->exp_class);
         if (etmp->exp_pad)
             *p++ = 0;
@@ -262,7 +262,7 @@ static ASN1_TYPE *generate_v3(const char *str, X509V3_CTX *cnf, int depth,
             && (asn1_tags.imp_tag == V_ASN1_SEQUENCE
                 || asn1_tags.imp_tag == V_ASN1_SET))
             hdr_constructed = V_ASN1_CONSTRUCTED;
-        ASN1_put_object(&p, hdr_constructed, hdr_len,
+        ASN1_put_object(&p, hdr_constructed, (int)hdr_len,
                         asn1_tags.imp_tag, asn1_tags.imp_class);
     }
 
@@ -301,8 +301,8 @@ static int asn1_cb(const char *elem, int len, void *bitstr)
         /* Look for the ':' in name value pairs */
         if (*p == ':') {
             vstart = p + 1;
-            vlen = len - (vstart - elem);
-            len = p - elem;
+            vlen = (int)(len - (vstart - elem));
+            len = (int)(p - elem);
             break;
         }
     }
@@ -407,7 +407,7 @@ static int parse_tagging(const char *vstart, int vlen, int *ptag, int *pclass)
         OPENSSL_PUT_ERROR(ASN1, ASN1_R_INVALID_NUMBER);
         return 0;
     }
-    *ptag = tag_num;
+    *ptag = (int)tag_num;
     /* If we have non numeric characters, parse them */
     if (eptr)
         vlen -= eptr - vstart;
@@ -618,7 +618,7 @@ static int asn1_str2tag(const char *tagstr, int len)
     };
 
     if (len == -1)
-        len = strlen(tagstr);
+        len = (int)strlen(tagstr);
 
     tntmp = tnst;
     for (i = 0; i < sizeof(tnst) / sizeof(struct tag_name_st); i++, tntmp++) {
@@ -760,7 +760,7 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             }
 
             atmp->value.asn1_string->data = rdata;
-            atmp->value.asn1_string->length = rdlen;
+            atmp->value.asn1_string->length = (int)rdlen;
             atmp->value.asn1_string->type = utype;
 
         } else if (format == ASN1_GEN_FORMAT_ASCII)
@@ -818,7 +818,7 @@ static int bitstr_cb(const char *elem, int len, void *bitstr)
         OPENSSL_PUT_ERROR(ASN1, ASN1_R_INVALID_NUMBER);
         return 0;
     }
-    if (!ASN1_BIT_STRING_set_bit(bitstr, bitnum, 1)) {
+    if (!ASN1_BIT_STRING_set_bit(bitstr, (int)bitnum, 1)) {
         OPENSSL_PUT_ERROR(ASN1, ERR_R_MALLOC_FAILURE);
         return 0;
     }

--- a/src/crypto/x509/by_dir.c
+++ b/src/crypto/x509/by_dir.c
@@ -313,7 +313,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, int type, X509_NAME *name,
             size_t idx;
             BY_DIR_HASH htmp, *hent;
             ent = sk_BY_DIR_ENTRY_value(ctx->dirs, i);
-            j = strlen(ent->dir) + 1 + 8 + 6 + 1 + 1;
+            j = (int)strlen(ent->dir) + 1 + 8 + 6 + 1 + 1;
             if (!BUF_MEM_grow(b, j)) {
                 OPENSSL_PUT_ERROR(X509, ERR_R_MALLOC_FAILURE);
                 goto finish;

--- a/src/crypto/x509/name_print.c
+++ b/src/crypto/x509/name_print.c
@@ -190,7 +190,7 @@ static int do_name_ex(BIO *out, const X509_NAME *n, int indent,
                     objbuf = "";
                 }
             }
-            objlen = strlen(objbuf);
+            objlen = (int)strlen(objbuf);
             if (!maybe_write(out, objbuf, objlen))
                 return -1;
             if ((objlen < fld_len) && (flags & XN_FLAG_FN_ALIGN)) {

--- a/src/crypto/x509/rsa_pss.c
+++ b/src/crypto/x509/rsa_pss.c
@@ -9,7 +9,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -207,11 +207,11 @@ int x509_rsa_ctx_to_pss(EVP_MD_CTX *ctx, X509_ALGOR *algor) {
 
   EVP_PKEY *pk = EVP_PKEY_CTX_get0_pkey(ctx->pctx);
   if (saltlen == -1) {
-    saltlen = EVP_MD_size(sigmd);
+    saltlen = (int)EVP_MD_size(sigmd);
   } else if (saltlen == -2) {
     // TODO(davidben): Forbid this mode. The world has largely standardized on
     // salt length matching hash length.
-    saltlen = EVP_PKEY_size(pk) - EVP_MD_size(sigmd) - 2;
+    saltlen = EVP_PKEY_size(pk) - (int)EVP_MD_size(sigmd) - 2;
     if (((EVP_PKEY_bits(pk) - 1) & 0x7) == 0) {
       saltlen--;
     }
@@ -277,7 +277,7 @@ int x509_rsa_pss_to_ctx(EVP_MD_CTX *ctx, const X509_ALGOR *sigalg,
 
   int saltlen = 20;
   if (pss->saltLength != NULL) {
-    saltlen = ASN1_INTEGER_get(pss->saltLength);
+    saltlen = (int)ASN1_INTEGER_get(pss->saltLength);
 
     /* Could perform more salt length sanity checks but the main
      * RSA routines will trap other invalid values anyway. */

--- a/src/crypto/x509/t_x509.c
+++ b/src/crypto/x509/t_x509.c
@@ -339,7 +339,7 @@ int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
                                                   && (s[2] <= 'Z')
                                                   && (s[3] == '='))
               ))) || (*s == '\0')) {
-            i = s - c;
+            i = (int)(s - c);
             if (BIO_write(bp, c, i) != i)
                 goto err;
             c = s + 1;          /* skip following slash */

--- a/src/crypto/x509/x509_att.c
+++ b/src/crypto/x509/x509_att.c
@@ -68,7 +68,7 @@
 
 int X509at_get_attr_count(const STACK_OF(X509_ATTRIBUTE) *x)
 {
-    return sk_X509_ATTRIBUTE_num(x);
+    return (int)sk_X509_ATTRIBUTE_num(x);
 }
 
 int X509at_get_attr_by_NID(const STACK_OF(X509_ATTRIBUTE) *x, int nid,
@@ -92,7 +92,7 @@ int X509at_get_attr_by_OBJ(const STACK_OF(X509_ATTRIBUTE) *sk,
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
-    n = sk_X509_ATTRIBUTE_num(sk);
+    n = (int)sk_X509_ATTRIBUTE_num(sk);
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_ATTRIBUTE_value(sk, lastpos);
         if (OBJ_cmp(ex->object, obj) == 0)
@@ -324,7 +324,7 @@ int X509_ATTRIBUTE_set1_data(X509_ATTRIBUTE *attr, int attrtype,
 
 int X509_ATTRIBUTE_count(const X509_ATTRIBUTE *attr)
 {
-    return sk_ASN1_TYPE_num(attr->set);
+    return (int)sk_ASN1_TYPE_num(attr->set);
 }
 
 ASN1_OBJECT *X509_ATTRIBUTE_get0_object(X509_ATTRIBUTE *attr)

--- a/src/crypto/x509/x509_cmp.c
+++ b/src/crypto/x509/x509_cmp.c
@@ -430,7 +430,7 @@ int X509_chain_check_suiteb(int *perror_depth, X509 *x, STACK_OF(X509) *chain,
         if (rv == X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED && flags != tflags)
             rv = X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256;
         if (perror_depth)
-            *perror_depth = i;
+            *perror_depth = (int)i;
     }
     return rv;
 }

--- a/src/crypto/x509/x509_lu.c
+++ b/src/crypto/x509/x509_lu.c
@@ -478,7 +478,7 @@ static int x509_object_idx_cnt(STACK_OF(X509_OBJECT) *h, int type,
         const X509_OBJECT *tobj, *pstmp;
         *pnmatch = 1;
         pstmp = &stmp;
-        for (tidx = idx + 1; tidx < (int)sk_X509_OBJECT_num(h); tidx++) {
+        for (tidx = (int)(idx + 1); tidx < (int)sk_X509_OBJECT_num(h); tidx++) {
             tobj = sk_X509_OBJECT_value(h, tidx);
             if (x509_object_cmp(&tobj, &pstmp))
                 break;
@@ -486,7 +486,7 @@ static int x509_object_idx_cnt(STACK_OF(X509_OBJECT) *h, int type,
         }
     }
 
-    return idx;
+    return (int)idx;
 }
 
 int X509_OBJECT_idx_by_subject(STACK_OF(X509_OBJECT) *h, int type,

--- a/src/crypto/x509/x509_obj.c
+++ b/src/crypto/x509/x509_obj.c
@@ -115,7 +115,7 @@ char *X509_NAME_oneline(const X509_NAME *a, char *buf, int len)
             i2t_ASN1_OBJECT(tmp_buf, sizeof(tmp_buf), ne->object);
             s = tmp_buf;
         }
-        l1 = strlen(s);
+        l1 = (int)strlen(s);
 
         type = ne->value->type;
         num = ne->value->length;

--- a/src/crypto/x509/x509_trs.c
+++ b/src/crypto/x509/x509_trs.c
@@ -139,7 +139,7 @@ int X509_TRUST_get_count(void)
 {
     if (!trtable)
         return X509_TRUST_COUNT;
-    return sk_X509_TRUST_num(trtable) + X509_TRUST_COUNT;
+    return (int)sk_X509_TRUST_num(trtable) + X509_TRUST_COUNT;
 }
 
 X509_TRUST *X509_TRUST_get0(int idx)
@@ -165,7 +165,7 @@ int X509_TRUST_get_by_id(int id)
     if (!sk_X509_TRUST_find(trtable, &idx, &tmp)) {
         return -1;
     }
-    return idx + X509_TRUST_COUNT;
+    return (int)(idx + X509_TRUST_COUNT);
 }
 
 int X509_TRUST_set(int *t, int trust)

--- a/src/crypto/x509/x509_v3.c
+++ b/src/crypto/x509/x509_v3.c
@@ -69,7 +69,7 @@ int X509v3_get_ext_count(const STACK_OF(X509_EXTENSION) *x)
 {
     if (x == NULL)
         return (0);
-    return (sk_X509_EXTENSION_num(x));
+    return (int)(sk_X509_EXTENSION_num(x));
 }
 
 int X509v3_get_ext_by_NID(const STACK_OF(X509_EXTENSION) *x, int nid,
@@ -93,7 +93,7 @@ int X509v3_get_ext_by_OBJ(const STACK_OF(X509_EXTENSION) *sk,
     lastpos++;
     if (lastpos < 0)
         lastpos = 0;
-    n = sk_X509_EXTENSION_num(sk);
+    n = (int)sk_X509_EXTENSION_num(sk);
     for (; lastpos < n; lastpos++) {
         ex = sk_X509_EXTENSION_value(sk, lastpos);
         if (OBJ_cmp(ex->object, obj) == 0)
@@ -115,7 +115,7 @@ int X509v3_get_ext_by_critical(const STACK_OF(X509_EXTENSION) *sk, int crit,
     }
 
     crit = !!crit;
-    int n = sk_X509_EXTENSION_num(sk);
+    int n = (int)sk_X509_EXTENSION_num(sk);
     for (; lastpos < n; lastpos++) {
         const X509_EXTENSION *ex = sk_X509_EXTENSION_value(sk, lastpos);
         if (X509_EXTENSION_get_critical(ex) == crit) {
@@ -161,7 +161,7 @@ STACK_OF(X509_EXTENSION) *X509v3_add_ext(STACK_OF(X509_EXTENSION) **x,
     } else
         sk = *x;
 
-    n = sk_X509_EXTENSION_num(sk);
+    n = (int)sk_X509_EXTENSION_num(sk);
     if (loc > n)
         loc = n;
     else if (loc < 0)

--- a/src/crypto/x509/x509_vfy.c
+++ b/src/crypto/x509/x509_vfy.c
@@ -230,7 +230,7 @@ int X509_verify_cert(X509_STORE_CTX *ctx)
         goto end;
     }
 
-    num = sk_X509_num(ctx->chain);
+    num = (int)sk_X509_num(ctx->chain);
     x = sk_X509_value(ctx->chain, num - 1);
     depth = param->depth;
 
@@ -306,7 +306,7 @@ int X509_verify_cert(X509_STORE_CTX *ctx)
         /*
          * Examine last certificate in chain and see if it is self signed.
          */
-        i = sk_X509_num(ctx->chain);
+        i = (int)sk_X509_num(ctx->chain);
         x = sk_X509_value(ctx->chain, i - 1);
 
         int is_self_signed;
@@ -425,7 +425,7 @@ int X509_verify_cert(X509_STORE_CTX *ctx)
                         X509_free(xtmp);
                         num--;
                     }
-                    ctx->last_untrusted = sk_X509_num(ctx->chain);
+                    ctx->last_untrusted = (int)sk_X509_num(ctx->chain);
                     retry = 1;
                     break;
                 }
@@ -738,7 +738,7 @@ static int check_name_constraints(X509_STORE_CTX *ctx)
     int i, j, rv;
     int has_name_constraints = 0;
     /* Check name constraints for all certificates */
-    for (i = sk_X509_num(ctx->chain) - 1; i >= 0; i--) {
+    for (i = (int)sk_X509_num(ctx->chain) - 1; i >= 0; i--) {
         X509 *x = sk_X509_value(ctx->chain, i);
         /* Ignore self issued certs unless last in chain */
         if (i && (x->ex_flags & EXFLAG_SI))
@@ -749,7 +749,7 @@ static int check_name_constraints(X509_STORE_CTX *ctx)
          * but if it includes constraints it is to be assumed it expects them
          * to be obeyed.
          */
-        for (j = sk_X509_num(ctx->chain) - 1; j > i; j--) {
+        for (j = (int)sk_X509_num(ctx->chain) - 1; j > i; j--) {
             NAME_CONSTRAINTS *nc = sk_X509_value(ctx->chain, j)->nc;
             if (nc) {
                 has_name_constraints = 1;
@@ -873,7 +873,7 @@ static int check_trust(X509_STORE_CTX *ctx)
          * overridden.
          */
         if (ok == X509_TRUST_REJECTED) {
-            ctx->error_depth = i;
+            ctx->error_depth = (int)i;
             ctx->current_cert = x;
             ctx->error = X509_V_ERR_CERT_REJECTED;
             ok = cb(0, ctx);
@@ -912,7 +912,7 @@ static int check_revocation(X509_STORE_CTX *ctx)
     if (!(ctx->param->flags & X509_V_FLAG_CRL_CHECK))
         return 1;
     if (ctx->param->flags & X509_V_FLAG_CRL_CHECK_ALL)
-        last = sk_X509_num(ctx->chain) - 1;
+        last = (int)(sk_X509_num(ctx->chain) - 1);
     else {
         /* If checking CRL paths this isn't the EE certificate */
         if (ctx->parent)
@@ -1558,7 +1558,7 @@ static int check_crl(X509_STORE_CTX *ctx, X509_CRL *crl)
     EVP_PKEY *ikey = NULL;
     int ok = 0, chnum, cnum;
     cnum = ctx->error_depth;
-    chnum = sk_X509_num(ctx->chain) - 1;
+    chnum = (int)(sk_X509_num(ctx->chain) - 1);
     /* if we have an alternative CRL issuer cert use that */
     if (ctx->current_issuer)
         issuer = ctx->current_issuer;
@@ -1699,7 +1699,7 @@ static int check_policy(X509_STORE_CTX *ctx)
     if (ctx->parent)
         return 1;
     ret = X509_policy_check(&ctx->tree, &ctx->explicit_policy, ctx->chain,
-                            ctx->param->policies, ctx->param->flags);
+                            ctx->param->policies, (unsigned int)(ctx->param->flags));
     if (ret == 0) {
         OPENSSL_PUT_ERROR(X509, ERR_R_MALLOC_FAILURE);
         ctx->error = X509_V_ERR_OUT_OF_MEM;
@@ -1796,7 +1796,7 @@ static int internal_verify(X509_STORE_CTX *ctx)
 
     cb = ctx->verify_cb;
 
-    n = sk_X509_num(ctx->chain);
+    n = (int)sk_X509_num(ctx->chain);
     ctx->error_depth = n - 1;
     n--;
     xi = sk_X509_value(ctx->chain, n);

--- a/src/crypto/x509/x509cset.c
+++ b/src/crypto/x509/x509cset.c
@@ -124,7 +124,7 @@ int X509_CRL_sort(X509_CRL *c)
     sk_X509_REVOKED_sort(c->crl->revoked);
     for (i = 0; i < sk_X509_REVOKED_num(c->crl->revoked); i++) {
         r = sk_X509_REVOKED_value(c->crl->revoked, i);
-        r->sequence = i;
+        r->sequence = (int)i;
     }
     c->crl->enc.modified = 1;
     return 1;
@@ -275,7 +275,7 @@ int X509_CRL_set1_signature_algo(X509_CRL *crl, const X509_ALGOR *algo)
 int X509_CRL_set1_signature_value(X509_CRL *crl, const uint8_t *sig,
                                   size_t sig_len)
 {
-    if (!ASN1_STRING_set(crl->signature, sig, sig_len)) {
+    if (!ASN1_STRING_set(crl->signature, sig, (int)sig_len)) {
       return 0;
     }
     crl->signature->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);

--- a/src/crypto/x509/x509name.c
+++ b/src/crypto/x509/x509name.c
@@ -100,7 +100,7 @@ int X509_NAME_entry_count(const X509_NAME *name)
 {
     if (name == NULL)
         return (0);
-    return (sk_X509_NAME_ENTRY_num(name->entries));
+    return (int)(sk_X509_NAME_ENTRY_num(name->entries));
 }
 
 int X509_NAME_get_index_by_NID(const X509_NAME *name, int nid, int lastpos)
@@ -126,7 +126,7 @@ int X509_NAME_get_index_by_OBJ(const X509_NAME *name, const ASN1_OBJECT *obj,
     if (lastpos < 0)
         lastpos = -1;
     sk = name->entries;
-    n = sk_X509_NAME_ENTRY_num(sk);
+    n = (int)sk_X509_NAME_ENTRY_num(sk);
     for (lastpos++; lastpos < n; lastpos++) {
         ne = sk_X509_NAME_ENTRY_value(sk, lastpos);
         if (OBJ_cmp(ne->object, obj) == 0)
@@ -155,7 +155,7 @@ X509_NAME_ENTRY *X509_NAME_delete_entry(X509_NAME *name, int loc)
         return (NULL);
     sk = name->entries;
     ret = sk_X509_NAME_ENTRY_delete(sk, loc);
-    n = sk_X509_NAME_ENTRY_num(sk);
+    n = (int)sk_X509_NAME_ENTRY_num(sk);
     name->modified = 1;
     if (loc == n)
         return (ret);
@@ -234,7 +234,7 @@ int X509_NAME_add_entry(X509_NAME *name, X509_NAME_ENTRY *ne, int loc,
     if (name == NULL)
         return (0);
     sk = name->entries;
-    n = sk_X509_NAME_ENTRY_num(sk);
+    n = (int)sk_X509_NAME_ENTRY_num(sk);
     if (loc > n)
         loc = n;
     else if (loc < 0)
@@ -269,7 +269,7 @@ int X509_NAME_add_entry(X509_NAME *name, X509_NAME_ENTRY *ne, int loc,
         goto err;
     }
     if (inc) {
-        n = sk_X509_NAME_ENTRY_num(sk);
+        n = (int)sk_X509_NAME_ENTRY_num(sk);
         for (i = loc + 1; i < n; i++)
             sk_X509_NAME_ENTRY_value(sk, i)->set += 1;
     }
@@ -363,7 +363,7 @@ int X509_NAME_ENTRY_set_data(X509_NAME_ENTRY *ne, int type,
                                       len, type,
                                       OBJ_obj2nid(ne->object)) ? 1 : 0;
     if (len < 0)
-        len = strlen((const char *)bytes);
+        len = (int)strlen((const char *)bytes);
     i = ASN1_STRING_set(ne->value, bytes, len);
     if (!i)
         return (0);

--- a/src/crypto/x509/x509spki.c
+++ b/src/crypto/x509/x509spki.c
@@ -84,7 +84,7 @@ NETSCAPE_SPKI *NETSCAPE_SPKI_b64_decode(const char *str, int len)
     size_t spki_len;
     NETSCAPE_SPKI *spki;
     if (len <= 0)
-        len = strlen(str);
+        len = (int)strlen(str);
     if (!EVP_DecodedLength(&spki_len, len)) {
         OPENSSL_PUT_ERROR(X509, X509_R_BASE64_DECODE_ERROR);
         return NULL;

--- a/src/crypto/x509/x_crl.c
+++ b/src/crypto/x509/x_crl.c
@@ -194,7 +194,7 @@ static int crl_set_issuers(X509_CRL *crl)
         }
 
         if (reason) {
-            rev->reason = ASN1_ENUMERATED_get(reason);
+            rev->reason = (int)ASN1_ENUMERATED_get(reason);
             ASN1_ENUMERATED_free(reason);
         } else
             rev->reason = CRL_REASON_NONE;

--- a/src/crypto/x509/x_name.c
+++ b/src/crypto/x509/x_name.c
@@ -235,7 +235,7 @@ static int x509_name_ex_d2i(ASN1_VALUE **val,
         entries = sk_STACK_OF_X509_NAME_ENTRY_value(intname, i);
         for (j = 0; j < sk_X509_NAME_ENTRY_num(entries); j++) {
             entry = sk_X509_NAME_ENTRY_value(entries, j);
-            entry->set = i;
+            entry->set = (int)i;
             if (!sk_X509_NAME_ENTRY_push(nm->entries, entry))
                 goto err;
             (void)sk_X509_NAME_ENTRY_set(entries, j, NULL);
@@ -267,7 +267,7 @@ static int x509_name_ex_i2d(ASN1_VALUE **val, unsigned char **out,
          !x509_name_canon(a))) {
         return -1;
     }
-    int ret = a->bytes->length;
+    int ret = (int)(a->bytes->length);
     if (out != NULL) {
         OPENSSL_memcpy(*out, a->bytes->data, ret);
         *out += ret;
@@ -490,7 +490,7 @@ static int asn1_string_canon(ASN1_STRING *out, ASN1_STRING *in)
         }
     }
 
-    out->length = to - out->data;
+    out->length = (int)(to - out->data);
 
     return 1;
 

--- a/src/crypto/x509/x_x509.c
+++ b/src/crypto/x509/x_x509.c
@@ -371,7 +371,7 @@ int X509_set1_signature_algo(X509 *x509, const X509_ALGOR *algo)
 
 int X509_set1_signature_value(X509 *x509, const uint8_t *sig, size_t sig_len)
 {
-    if (!ASN1_STRING_set(x509->signature, sig, sig_len)) {
+    if (!ASN1_STRING_set(x509->signature, sig, (int)sig_len)) {
       return 0;
     }
     x509->signature->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);

--- a/src/crypto/x509v3/pcy_tree.c
+++ b/src/crypto/x509v3/pcy_tree.c
@@ -161,7 +161,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
     int any_skip;
     int map_skip;
     *ptree = NULL;
-    n = sk_X509_num(certs);
+    n = (int)sk_X509_num(certs);
 
 #if 0
     /* Disable policy mapping for now... */
@@ -214,7 +214,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
                 explicit_policy--;
             if ((cache->explicit_skip != -1)
                 && (cache->explicit_skip < explicit_policy))
-                explicit_policy = cache->explicit_skip;
+                explicit_policy = (int)(cache->explicit_skip);
         }
     }
 
@@ -279,7 +279,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
                 any_skip--;
             if ((cache->any_skip >= 0)
                 && (cache->any_skip < any_skip))
-                any_skip = cache->any_skip;
+                any_skip = (int)(cache->any_skip);
         }
 
         if (map_skip == 0)
@@ -289,7 +289,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
                 map_skip--;
             if ((cache->map_skip >= 0)
                 && (cache->map_skip < map_skip))
-                map_skip = cache->map_skip;
+                map_skip = (int)(cache->map_skip);
         }
 
     }
@@ -499,7 +499,7 @@ static int tree_prune(X509_POLICY_TREE *tree, X509_POLICY_LEVEL *curr)
     int i;
     nodes = curr->nodes;
     if (curr->flags & X509_V_FLAG_INHIBIT_MAP) {
-        for (i = sk_X509_POLICY_NODE_num(nodes) - 1; i >= 0; i--) {
+        for (i = (int)sk_X509_POLICY_NODE_num(nodes) - 1; i >= 0; i--) {
             node = sk_X509_POLICY_NODE_value(nodes, i);
             /* Delete any mapped data: see RFC 3280 XXXX */
             if (node->data->flags & POLICY_DATA_FLAG_MAP_MASK) {
@@ -513,7 +513,7 @@ static int tree_prune(X509_POLICY_TREE *tree, X509_POLICY_LEVEL *curr)
     for (;;) {
         --curr;
         nodes = curr->nodes;
-        for (i = sk_X509_POLICY_NODE_num(nodes) - 1; i >= 0; i--) {
+        for (i = (int)sk_X509_POLICY_NODE_num(nodes) - 1; i >= 0; i--) {
             node = sk_X509_POLICY_NODE_value(nodes, i);
             if (node->nchild == 0) {
                 node->parent->nchild--;

--- a/src/crypto/x509v3/v3_alt.c
+++ b/src/crypto/x509v3/v3_alt.c
@@ -529,7 +529,7 @@ GENERAL_NAME *a2i_GENERAL_NAME(GENERAL_NAME *out,
     if (is_string) {
         if (!(gen->d.ia5 = ASN1_IA5STRING_new()) ||
             !ASN1_STRING_set(gen->d.ia5, (unsigned char *)value,
-                             strlen(value))) {
+                             (int)strlen(value))) {
             OPENSSL_PUT_ERROR(X509V3, ERR_R_MALLOC_FAILURE);
             goto err;
         }
@@ -601,7 +601,7 @@ static int do_othername(GENERAL_NAME *gen, const char *value, X509V3_CTX *ctx)
     ASN1_TYPE_free(gen->d.otherName->value);
     if (!(gen->d.otherName->value = ASN1_generate_v3(p + 1, ctx)))
         return 0;
-    objlen = p - value;
+    objlen = (int)(p - value);
     objtmp = OPENSSL_malloc(objlen + 1);
     if (objtmp == NULL)
         return 0;

--- a/src/crypto/x509v3/v3_conf.c
+++ b/src/crypto/x509v3/v3_conf.c
@@ -296,7 +296,7 @@ static X509_EXTENSION *v3_generic_extension(const char *ext, const char *value,
     }
 
     oct->data = ext_der;
-    oct->length = ext_len;
+    oct->length = (int)ext_len;
     ext_der = NULL;
 
     extension = X509_EXTENSION_create_by_OBJ(NULL, obj, crit, oct);

--- a/src/crypto/x509v3/v3_cpols.c
+++ b/src/crypto/x509v3/v3_cpols.c
@@ -248,7 +248,7 @@ static POLICYINFO *policy_section(X509V3_CTX *ctx,
                 goto err;
             }
             if (!ASN1_STRING_set(qual->d.cpsuri, cnf->value,
-                                 strlen(cnf->value)))
+                                 (int)strlen(cnf->value)))
                 goto merr;
         } else if (!x509v3_name_cmp(cnf->name, "userNotice")) {
             STACK_OF(CONF_VALUE) *unot;
@@ -320,7 +320,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
             if (not->exptext == NULL)
                 goto merr;
             if (!ASN1_STRING_set(not->exptext, cnf->value,
-                                 strlen(cnf->value)))
+                                 (int)strlen(cnf->value)))
                 goto merr;
         } else if (!strcmp(cnf->name, "organization")) {
             NOTICEREF *nref;
@@ -335,7 +335,7 @@ static POLICYQUALINFO *notice_section(X509V3_CTX *ctx,
             else
                 nref->organization->type = V_ASN1_VISIBLESTRING;
             if (!ASN1_STRING_set(nref->organization, cnf->value,
-                                 strlen(cnf->value)))
+                                 (int)strlen(cnf->value)))
                 goto merr;
         } else if (!strcmp(cnf->name, "noticeNumbers")) {
             NOTICEREF *nref;

--- a/src/crypto/x509v3/v3_ia5.c
+++ b/src/crypto/x509v3/v3_ia5.c
@@ -110,7 +110,7 @@ static ASN1_IA5STRING *s2i_ASN1_IA5STRING(X509V3_EXT_METHOD *method,
     }
     if (!(ia5 = ASN1_IA5STRING_new()))
         goto err;
-    if (!ASN1_STRING_set(ia5, str, strlen(str))) {
+    if (!ASN1_STRING_set(ia5, str, (int)strlen(str))) {
         ASN1_IA5STRING_free(ia5);
         goto err;
     }

--- a/src/crypto/x509v3/v3_info.c
+++ b/src/crypto/x509v3/v3_info.c
@@ -132,7 +132,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_INFO_ACCESS(
         tret = tmp;
         vtmp = sk_CONF_VALUE_value(tret, i);
         i2t_ASN1_OBJECT(objtmp, sizeof objtmp, desc->method);
-        nlen = strlen(objtmp) + strlen(vtmp->name) + 5;
+        nlen = (int)(strlen(objtmp) + strlen(vtmp->name) + 5);
         ntmp = OPENSSL_malloc(nlen);
         if (ntmp == NULL)
             goto err;
@@ -182,7 +182,7 @@ static AUTHORITY_INFO_ACCESS *v2i_AUTHORITY_INFO_ACCESS(X509V3_EXT_METHOD
             OPENSSL_PUT_ERROR(X509V3, X509V3_R_INVALID_SYNTAX);
             goto err;
         }
-        objlen = ptmp - cnf->name;
+        objlen = (int)(ptmp - cnf->name);
         ctmp.name = ptmp + 1;
         ctmp.value = cnf->value;
         if (!v2i_GENERAL_NAME_ex(acc->location, method, ctx, &ctmp, 0))

--- a/src/crypto/x509v3/v3_lib.c
+++ b/src/crypto/x509v3/v3_lib.c
@@ -261,7 +261,7 @@ void *X509V3_get_d2i(const STACK_OF(X509_EXTENSION) *extensions, int nid,
             if (out_idx) {
                 /* TODO(https://crbug.com/boringssl/379): Consistently reject
                  * duplicate extensions. */
-                *out_idx = i;
+                *out_idx = (int)i;
                 found_ex = ex;
                 break;
             } else if (found_ex) {

--- a/src/crypto/x509v3/v3_purp.c
+++ b/src/crypto/x509v3/v3_purp.c
@@ -170,7 +170,7 @@ int X509_PURPOSE_get_count(void)
 {
     if (!xptable)
         return X509_PURPOSE_COUNT;
-    return sk_X509_PURPOSE_num(xptable) + X509_PURPOSE_COUNT;
+    return (int)(sk_X509_PURPOSE_num(xptable) + X509_PURPOSE_COUNT);
 }
 
 X509_PURPOSE *X509_PURPOSE_get0(int idx)
@@ -208,7 +208,7 @@ int X509_PURPOSE_get_by_id(int purpose)
     sk_X509_PURPOSE_sort(xptable);
     if (!sk_X509_PURPOSE_find(xptable, &idx, &tmp))
         return -1;
-    return idx + X509_PURPOSE_COUNT;
+    return (int)(idx + X509_PURPOSE_COUNT);
 }
 
 int X509_PURPOSE_add(int id, int trust, int flags,
@@ -864,7 +864,7 @@ uint32_t X509_get_extension_flags(X509 *x)
     /* Ignore the return value. On failure, |x->ex_flags| will include
      * |EXFLAG_INVALID|. */
     x509v3_cache_extensions(x);
-    return x->ex_flags;
+    return (uint32_t)(x->ex_flags);
 }
 
 uint32_t X509_get_key_usage(X509 *x)
@@ -873,7 +873,7 @@ uint32_t X509_get_key_usage(X509 *x)
         return 0;
     }
     if (x->ex_flags & EXFLAG_KUSAGE)
-        return x->ex_kusage;
+        return (uint32_t)(x->ex_kusage);
     return UINT32_MAX;
 }
 
@@ -883,7 +883,7 @@ uint32_t X509_get_extended_key_usage(X509 *x)
         return 0;
     }
     if (x->ex_flags & EXFLAG_XKUSAGE)
-        return x->ex_xkusage;
+        return (uint32_t)(x->ex_xkusage);
     return UINT32_MAX;
 }
 

--- a/src/crypto/x509v3/v3_skey.c
+++ b/src/crypto/x509v3/v3_skey.c
@@ -99,7 +99,7 @@ ASN1_OCTET_STRING *s2i_ASN1_OCTET_STRING(X509V3_EXT_METHOD *method,
         return NULL;
     }
 
-    oct->length = length;
+    oct->length = (int)length;
 
     return oct;
 

--- a/src/crypto/x509v3/v3_utl.c
+++ b/src/crypto/x509v3/v3_utl.c
@@ -560,7 +560,7 @@ int x509v3_name_cmp(const char *name, const char *cmp)
 {
     int len, ret;
     char c;
-    len = strlen(cmp);
+    len = (int)strlen(cmp);
     if ((ret = strncmp(name, cmp, len)))
         return ret;
     c = name[len];
@@ -1427,7 +1427,7 @@ int X509V3_NAME_from_section(X509_NAME *nm, STACK_OF (CONF_VALUE) * dn_sk,
             type++;
         } else
             mval = 0;
-        if (!X509_NAME_add_entry_by_txt(nm, type, chtype,
+        if (!X509_NAME_add_entry_by_txt(nm, type, (int)chtype,
                                         (unsigned char *)v->value, -1, -1,
                                         mval))
             return 0;

--- a/src/ssl/bio_ssl.cc
+++ b/src/ssl/bio_ssl.cc
@@ -109,7 +109,7 @@ static long ssl_ctrl(BIO *bio, int cmd, long num, void *ptr) {
       // |bio->next_bio| with |ssl|'s rbio here, and on |BIO_CTRL_PUSH|. We call
       // into the corresponding |BIO| directly. (We can implement the upstream
       // behavior if it ends up necessary.)
-      bio->shutdown = num;
+      bio->shutdown = (int)num;
       bio->ptr = ptr;
       bio->init = 1;
       return 1;
@@ -118,7 +118,7 @@ static long ssl_ctrl(BIO *bio, int cmd, long num, void *ptr) {
       return bio->shutdown;
 
     case BIO_CTRL_SET_CLOSE:
-      bio->shutdown = num;
+      bio->shutdown = (int)num;
       return 1;
 
     case BIO_CTRL_WPENDING:

--- a/src/ssl/d1_both.cc
+++ b/src/ssl/d1_both.cc
@@ -580,7 +580,7 @@ static bool add_outgoing(SSL *ssl, bool is_ccs, Array<uint8_t> data) {
       &ssl->d1->outgoing_messages[ssl->d1->outgoing_messages_len];
   size_t len;
   data.Release(&msg->data, &len);
-  msg->len = len;
+  msg->len = (uint32_t)len;
   msg->epoch = ssl->d1->w_epoch;
   msg->is_ccs = is_ccs;
 
@@ -694,7 +694,7 @@ static enum seal_result_t seal_next_message(SSL *ssl, uint8_t *out,
       !CBB_add_u24(cbb.get(), hdr.msg_len) ||
       !CBB_add_u16(cbb.get(), hdr.seq) ||
       !CBB_add_u24(cbb.get(), ssl->d1->outgoing_offset) ||
-      !CBB_add_u24(cbb.get(), todo) ||
+      !CBB_add_u24(cbb.get(), (uint32_t)todo) ||
       !CBB_add_bytes(cbb.get(), CBS_data(&body), todo) ||
       !CBB_finish(cbb.get(), NULL, &frag_len)) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
@@ -792,7 +792,7 @@ static int send_flight(SSL *ssl) {
       return -1;
     }
 
-    int bio_ret = BIO_write(ssl->wbio.get(), packet.data(), packet_len);
+    int bio_ret = BIO_write(ssl->wbio.get(), packet.data(), (int)packet_len);
     if (bio_ret <= 0) {
       // Retry this packet the next time around.
       ssl->d1->outgoing_written = old_written;

--- a/src/ssl/extensions.cc
+++ b/src/ssl/extensions.cc
@@ -1252,7 +1252,7 @@ static bool ext_npn_parse_serverhello(SSL_HANDSHAKE *hs, uint8_t *out_alert,
   uint8_t *selected;
   uint8_t selected_len;
   if (ssl->ctx->next_proto_select_cb(
-          ssl, &selected, &selected_len, orig_contents, orig_len,
+          ssl, &selected, &selected_len, orig_contents, (unsigned int)orig_len,
           ssl->ctx->next_proto_select_cb_arg) != SSL_TLSEXT_ERR_OK ||
       !ssl->s3->next_proto_negotiated.CopyFrom(
           MakeConstSpan(selected, selected_len))) {
@@ -1569,7 +1569,7 @@ bool ssl_negotiate_alpn(SSL_HANDSHAKE *hs, uint8_t *out_alert,
   uint8_t selected_len;
   int ret = ssl->ctx->alpn_select_cb(
       ssl, &selected, &selected_len, CBS_data(&protocol_name_list),
-      CBS_len(&protocol_name_list), ssl->ctx->alpn_select_cb_arg);
+      (unsigned int)CBS_len(&protocol_name_list), ssl->ctx->alpn_select_cb_arg);
   // ALPN is required when QUIC is used.
   if (ssl->quic_method &&
       (ret == SSL_TLSEXT_ERR_NOACK || ret == SSL_TLSEXT_ERR_ALERT_WARNING)) {
@@ -1979,7 +1979,7 @@ static bool ext_pre_shared_key_add_clienthello(const SSL_HANDSHAKE *hs,
 
   struct OPENSSL_timeval now;
   ssl_get_current_time(ssl, &now);
-  uint32_t ticket_age = 1000 * (now.tv_sec - ssl->session->time);
+  uint32_t ticket_age = (uint32_t)(1000 * (now.tv_sec - ssl->session->time));
   uint32_t obfuscated_ticket_age = ticket_age + ssl->session->ticket_age_add;
 
   // Fill in a placeholder zero binder of the appropriate length. It will be

--- a/src/ssl/handshake_client.cc
+++ b/src/ssl/handshake_client.cc
@@ -826,7 +826,7 @@ static enum ssl_hs_wait_t do_read_server_hello(SSL_HANDSHAKE *hs) {
       return ssl_hs_error;
     }
     // Note: session_id could be empty.
-    hs->new_session->session_id_length = CBS_len(&server_hello.session_id);
+    hs->new_session->session_id_length = (unsigned int)CBS_len(&server_hello.session_id);
     OPENSSL_memcpy(hs->new_session->session_id,
                    CBS_data(&server_hello.session_id),
                    CBS_len(&server_hello.session_id));

--- a/src/ssl/handshake_server.cc
+++ b/src/ssl/handshake_server.cc
@@ -376,7 +376,7 @@ static const SSL_CIPHER *choose_cipher(
         // This element of |prio| is in a group. Update the minimum index found
         // so far and continue looking.
         if (group_min == -1 || (size_t)group_min > cipher_index) {
-          group_min = cipher_index;
+          group_min = (int)cipher_index;
         }
       } else {
         if (group_min != -1 && (size_t)group_min < cipher_index) {

--- a/src/ssl/s3_both.cc
+++ b/src/ssl/s3_both.cc
@@ -333,7 +333,7 @@ int tls_flush_flight(SSL *ssl) {
     int ret = BIO_write(
         ssl->wbio.get(),
         ssl->s3->pending_flight->data + ssl->s3->pending_flight_offset,
-        ssl->s3->pending_flight->length - ssl->s3->pending_flight_offset);
+        (int)(ssl->s3->pending_flight->length - ssl->s3->pending_flight_offset));
     if (ret <= 0) {
       ssl->s3->rwstate = SSL_ERROR_WANT_WRITE;
       return ret;

--- a/src/ssl/s3_pkt.cc
+++ b/src/ssl/s3_pkt.cc
@@ -177,7 +177,7 @@ int tls_write_app_data(SSL *ssl, bool *out_needs_handshake, const uint8_t *in,
     }
 
     const size_t nw = std::min(max_send_fragment, size_t{n});
-    int ret = do_tls_write(ssl, SSL3_RT_APPLICATION_DATA, &in[tot], nw);
+    int ret = do_tls_write(ssl, SSL3_RT_APPLICATION_DATA, &in[tot], (unsigned int)nw);
     if (ret <= 0) {
       ssl->s3->wnum = tot;
       return ret;

--- a/src/ssl/ssl_asn1.cc
+++ b/src/ssl/ssl_asn1.cc
@@ -601,9 +601,9 @@ UniquePtr<SSL_SESSION> SSL_SESSION_parse(CBS *cbs,
     return nullptr;
   }
   OPENSSL_memcpy(ret->session_id, CBS_data(&session_id), CBS_len(&session_id));
-  ret->session_id_length = CBS_len(&session_id);
+  ret->session_id_length = (unsigned int)CBS_len(&session_id);
   OPENSSL_memcpy(ret->secret, CBS_data(&secret), CBS_len(&secret));
-  ret->secret_length = CBS_len(&secret);
+  ret->secret_length = (int)CBS_len(&secret);
 
   CBS child;
   uint64_t timeout;
@@ -876,7 +876,7 @@ int i2d_SSL_SESSION(SSL_SESSION *in, uint8_t **pp) {
   }
   OPENSSL_free(out);
 
-  return len;
+  return (int)len;
 }
 
 SSL_SESSION *SSL_SESSION_from_bytes(const uint8_t *in, size_t in_len,

--- a/src/ssl/ssl_buffer.cc
+++ b/src/ssl/ssl_buffer.cc
@@ -260,7 +260,7 @@ static int tls_write_buffer_flush(SSL *ssl) {
   SSLBuffer *buf = &ssl->s3->write_buffer;
 
   while (!buf->empty()) {
-    int ret = BIO_write(ssl->wbio.get(), buf->data(), buf->size());
+    int ret = BIO_write(ssl->wbio.get(), buf->data(), (int)(buf->size()));
     if (ret <= 0) {
       ssl->s3->rwstate = SSL_ERROR_WANT_WRITE;
       return ret;
@@ -277,7 +277,7 @@ static int dtls_write_buffer_flush(SSL *ssl) {
     return 1;
   }
 
-  int ret = BIO_write(ssl->wbio.get(), buf->data(), buf->size());
+  int ret = BIO_write(ssl->wbio.get(), buf->data(), (int)(buf->size()));
   if (ret <= 0) {
     ssl->s3->rwstate = SSL_ERROR_WANT_WRITE;
     // If the write failed, drop the write buffer anyway. Datagram transports

--- a/src/ssl/ssl_lib.cc
+++ b/src/ssl/ssl_lib.cc
@@ -2170,7 +2170,7 @@ found:
 void SSL_get0_next_proto_negotiated(const SSL *ssl, const uint8_t **out_data,
                                     unsigned *out_len) {
   *out_data = ssl->s3->next_proto_negotiated.data();
-  *out_len = ssl->s3->next_proto_negotiated.size();
+  *out_len = (unsigned)(ssl->s3->next_proto_negotiated.size());
 }
 
 void SSL_CTX_set_next_protos_advertised_cb(
@@ -2226,10 +2226,10 @@ void SSL_get0_alpn_selected(const SSL *ssl, const uint8_t **out_data,
                             unsigned *out_len) {
   if (SSL_in_early_data(ssl) && !ssl->server) {
     *out_data = ssl->s3->hs->early_session->early_alpn.data();
-    *out_len = ssl->s3->hs->early_session->early_alpn.size();
+    *out_len = (unsigned)(ssl->s3->hs->early_session->early_alpn.size());
   } else {
     *out_data = ssl->s3->alpn_selected.data();
-    *out_len = ssl->s3->alpn_selected.size();
+    *out_len = (unsigned)(ssl->s3->alpn_selected.size());
   }
 }
 

--- a/src/ssl/ssl_session.cc
+++ b/src/ssl/ssl_session.cc
@@ -505,7 +505,7 @@ static int ssl_encrypt_ticket_with_cipher_ctx(SSL_HANDSHAKE *hs, CBB *out,
   total = session_len;
 #else
   int len;
-  if (!EVP_EncryptUpdate(ctx.get(), ptr + total, &len, session_buf, session_len)) {
+  if (!EVP_EncryptUpdate(ctx.get(), ptr + total, &len, session_buf, (int)session_len)) {
     return 0;
   }
   total += len;
@@ -672,7 +672,7 @@ static enum ssl_hs_wait_t ssl_lookup_session(
   if (!session && ssl->session_ctx->get_session_cb != nullptr) {
     int copy = 1;
     session.reset(ssl->session_ctx->get_session_cb(ssl, session_id.data(),
-                                                   session_id.size(), &copy));
+                                                   (int)(session_id.size()), &copy));
     if (!session) {
       return ssl_hs_ok;
     }
@@ -990,7 +990,7 @@ int SSL_SESSION_set1_id(SSL_SESSION *session, const uint8_t *sid,
 
   // Use memmove in case someone passes in the output of |SSL_SESSION_get_id|.
   OPENSSL_memmove(session->session_id, sid, sid_len);
-  session->session_id_length = sid_len;
+  session->session_id_length = (unsigned int)sid_len;
   return 1;
 }
 

--- a/src/ssl/tls13_both.cc
+++ b/src/ssl/tls13_both.cc
@@ -520,7 +520,7 @@ bool tls13_add_certificate(SSL_HANDSHAKE *hs) {
   if (!ssl->method->init_message(ssl, cbb.get(), body,
                                  SSL3_MT_COMPRESSED_CERTIFICATE) ||
       !CBB_add_u16(body, hs->cert_compression_alg_id) ||
-      !CBB_add_u24(body, msg.size()) ||
+      !CBB_add_u24(body, (uint32_t)(msg.size())) ||
       !CBB_add_u24_length_prefixed(body, &compressed)) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
     return false;

--- a/src/ssl/tls13_enc.cc
+++ b/src/ssl/tls13_enc.cc
@@ -325,7 +325,7 @@ bool tls13_derive_resumption_secret(SSL_HANDSHAKE *hs) {
     OPENSSL_PUT_ERROR(SSL, ERR_R_INTERNAL_ERROR);
     return false;
   }
-  hs->new_session->secret_length = hs->transcript.DigestLen();
+  hs->new_session->secret_length = (int)(hs->transcript.DigestLen());
   return derive_secret(
       hs, MakeSpan(hs->new_session->secret, hs->new_session->secret_length),
       label_to_span(kTLS13LabelResumption));


### PR DESCRIPTION
This patch fixed 32bit conversion warning (-Wshorten-64-to-32) as seem from default SPM builds in downstream projects
  * Upstream fixes will be submitted to BoringSSL repo separately 

### Build test verification 

```bash
swift build --target openssl_grpc && swift test   
```
---
cc @paulb777 @wu-hui