### PR TITLE
add privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,9 @@ let package = Package(
         "src/third_party/fiat/",
         "src/include/",
       ],
+      resources: [
+        .copy("PrivacyInfo.xcprivacy"),
+      ],
       publicHeadersPath: "src/include",
       cSettings: [
         .define("OPENSSL_NO_ASM", to: "1"),

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
BoringSSL usage stat and fstat.

ref: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc

fixes #14 